### PR TITLE
Make debug macros overrideable via compiler flags

### DIFF
--- a/src/ship/mdns/mdns_entry.c
+++ b/src/ship/mdns/mdns_entry.c
@@ -55,7 +55,9 @@
 #include "src/common/struct_util.h"
 
 /** Set MDNS_ENTRY_DEBUG 1 to enable debug prints */
+#ifndef MDNS_ENTRY_DEBUG
 #define MDNS_ENTRY_DEBUG 0
+#endif
 
 /** mDNS Entry debug printf(), enabled whith MDNS_DEBUG = 1 */
 #if MDNS_ENTRY_DEBUG

--- a/src/ship/mdns/ship_mdns_bonjour.c
+++ b/src/ship/mdns/ship_mdns_bonjour.c
@@ -94,7 +94,9 @@
 #include "src/ship/ship_connection/types.h"
 
 /** Set MDNS_DEBUG 1 to enable debug prints */
+#ifndef MDNS_DEBUG
 #define MDNS_DEBUG 0
+#endif
 
 /** mDNS debug printf(), enabled whith MDNS_DEBUG = 1 */
 #if MDNS_DEBUG

--- a/src/ship/mdns/ship_mdns_freertos.c
+++ b/src/ship/mdns/ship_mdns_freertos.c
@@ -33,7 +33,9 @@
 #include "src/ship/mdns/ship_mdns.h"
 
 /** Set MDNS_DEBUG 1 to enable debug prints */
+#ifndef MDNS_DEBUG
 #define MDNS_DEBUG 0
+#endif
 
 /** mDNS debug printf(), enabled whith MDNS_DEBUG = 1 */
 #if MDNS_DEBUG

--- a/src/ship/ship_connection/ship_connection_debug.h
+++ b/src/ship/ship_connection/ship_connection_debug.h
@@ -25,7 +25,9 @@
 #include "src/ship/model/types.h"
 
 /** Set SHIP_CONNECTION_DEBUG 1 to enable debug prints */
+#ifndef SHIP_CONNECTION_DEBUG
 #define SHIP_CONNECTION_DEBUG 0
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/ship/ship_node/ship_node.c
+++ b/src/ship/ship_node/ship_node.c
@@ -36,7 +36,9 @@
 #include "src/ship/websocket/websocket_client_creator.h"
 
 /** Set SHIP_NODE_DEBUG 1 to enable debug prints */
+#ifndef SHIP_NODE_DEBUG
 #define SHIP_NODE_DEBUG 0
+#endif
 
 /** Ship node debug printf(), enabled whith SHIP_NODE_DEBUG = 1 */
 #if SHIP_NODE_DEBUG

--- a/src/ship/tls_certificate/tls_certificate_mbedtls.c
+++ b/src/ship/tls_certificate/tls_certificate_mbedtls.c
@@ -32,7 +32,9 @@
 #include "src/ship/tls_certificate/tls_certificate.h"
 
 /** Set TLS_CERTIFICATE_MBEDTLS_DEBUG 1 to enable debug prints */
+#ifndef TLS_CERTIFICATE_MBEDTLS_DEBUG
 #define TLS_CERTIFICATE_MBEDTLS_DEBUG 0
+#endif
 
 /** Tls Certificate mbedTLS debug printf(), enabled whith TLS_CERTIFICATE_MBEDTLS_DEBUG = 1 */
 #if TLS_CERTIFICATE_MBEDTLS_DEBUG

--- a/src/ship/websocket/http_server.c
+++ b/src/ship/websocket/http_server.c
@@ -37,7 +37,9 @@
 #include "src/ship/websocket/websocket_server_creator.h"
 
 /** Set HTTP_SERVER_DEBUG 1 to enable debug prints */
+#ifndef HTTP_SERVER_DEBUG
 #define HTTP_SERVER_DEBUG 0
+#endif
 
 /** Http server debug printf(), enabled whith HTTP_SERVER_DEBUG = 1 */
 #if HTTP_SERVER_DEBUG

--- a/src/ship/websocket/websocket_debug.h
+++ b/src/ship/websocket/websocket_debug.h
@@ -28,7 +28,9 @@
 /** Set WEBSOCKET_DEBUG 1 to enable debug prints
  *  Set WEBSOCKET_DEBUG 2 to enable extra debug prints
  */
+#ifndef WEBSOCKET_DEBUG
 #define WEBSOCKET_DEBUG 0
+#endif
 
 /**
  * @defgroup WebsocketDebug Websocket debug printf() and hexdump,

--- a/src/spine/device/device_local.c
+++ b/src/spine/device/device_local.c
@@ -47,7 +47,9 @@
 #include "src/spine/subscription/subscription_manager.h"
 
 /** Set DEVICE_LOCAL_DEBUG 1 to enable debug prints */
+#ifndef DEVICE_LOCAL_DEBUG
 #define DEVICE_LOCAL_DEBUG 0
+#endif
 
 /** mDNS debug printf(), enabled whith MDNS_DEBUG = 1 */
 #if DEVICE_LOCAL_DEBUG

--- a/src/spine/device/sender.c
+++ b/src/spine/device/sender.c
@@ -32,7 +32,9 @@
 #include "src/spine/model/subscription_management_types.h"
 
 /** Set SENDER_DEBUG 1 to enable debug prints */
+#ifndef SENDER_DEBUG
 #define SENDER_DEBUG 0
+#endif
 
 /** Sender debug printf(), enabled whith SENDER_DEBUG = 1 */
 #if SENDER_DEBUG


### PR DESCRIPTION
Wrap all *_DEBUG default definitions with #ifndef guards so that debug logging can be enabled via compiler flags (e.g. -DSHIP_CONNECTION_DEBUG=1).

Previously, OpenEEBUS unconditionally redefined these macros to 0 in headers and .c files, overriding values passed on the compiler command line and making it impossible to enable module-level debug output without modifying sources.

This change preserves the existing default behaviour (debug disabled), while allowing integrators to selectively enable debug logging at build time.