### PR TITLE
Update EG LPC event handlers to include entity address

### DIFF
--- a/examples/hems/eg_lpc_listener.c
+++ b/examples/hems/eg_lpc_listener.c
@@ -45,13 +45,20 @@ static void OnRemoteEntityConnect(EgLpListenerObject* self, const EntityAddressT
 static void OnRemoteEntityDisconnect(EgLpListenerObject* self, const EntityAddressType* entity_addr);
 static void OnPowerLimitReceive(
     EgLpListenerObject* self,
+    const EntityAddressType* entity_addr,
     const ScaledValue* power_limit,
     const DurationType* duration,
     bool is_active
 );
-static void OnFailsafePowerLimitReceive(EgLpListenerObject* self, const ScaledValue* power_limit);
-static void OnFailsafeDurationReceive(EgLpListenerObject* self, const DurationType* duration);
-static void OnHeartbeatReceive(EgLpListenerObject* self, uint64_t heartbeat_counter);
+static void OnFailsafePowerLimitReceive(
+    EgLpListenerObject* self,
+    const EntityAddressType* entity_addr,
+    const ScaledValue* power_limit
+);
+static void
+OnFailsafeDurationReceive(EgLpListenerObject* self, const EntityAddressType* entity_addr, const DurationType* duration);
+static void
+OnHeartbeatReceive(EgLpListenerObject* self, const EntityAddressType* entity_addr, uint64_t heartbeat_counter);
 
 static const EgLpListenerInterface eg_lpc_listener_methods = {
     .destruct                        = Destruct,
@@ -100,31 +107,44 @@ void OnRemoteEntityDisconnect(EgLpListenerObject* self, const EntityAddressType*
 
 void OnPowerLimitReceive(
     EgLpListenerObject* self,
+    const EntityAddressType* entity_addr,
     const ScaledValue* power_limit,
     const EebusDuration* duration,
     bool is_active
 ) {
   UNUSED(self);
+  UNUSED(entity_addr);
 
   ScaledValuePrint("EG LPC Power Limit received %sW, ", power_limit);
   EebusDurationPrint("duration = %s, ", duration);
   printf("active = %s\n", is_active ? "true" : "false");
 }
 
-void OnFailsafePowerLimitReceive(EgLpListenerObject* self, const ScaledValue* power_limit) {
+void OnFailsafePowerLimitReceive(
+    EgLpListenerObject* self,
+    const EntityAddressType* entity_addr,
+    const ScaledValue* power_limit
+) {
   UNUSED(self);
+  UNUSED(entity_addr);
 
   ScaledValuePrint("EG LPC Failsafe Active Power Limit received:  %sW\n", power_limit);
 }
 
-void OnFailsafeDurationReceive(EgLpListenerObject* self, const DurationType* duration) {
+void OnFailsafeDurationReceive(
+    EgLpListenerObject* self,
+    const EntityAddressType* entity_addr,
+    const DurationType* duration
+) {
   UNUSED(self);
+  UNUSED(entity_addr);
 
   EebusDurationPrint("EG LPC Failsafe Duration Minimum received: %s\n", duration);
 }
 
-void OnHeartbeatReceive(EgLpListenerObject* self, uint64_t heartbeat_counter) {
+void OnHeartbeatReceive(EgLpListenerObject* self, const EntityAddressType* entity_addr, uint64_t heartbeat_counter) {
   UNUSED(self);
+  UNUSED(entity_addr);
 
   printf("EG LPC Heartbeat received, counter = %" PRIu64 "\n", heartbeat_counter);
 }

--- a/src/use_case/actor/eg/eg_lp_events.c
+++ b/src/use_case/actor/eg/eg_lp_events.c
@@ -182,7 +182,13 @@ void OnLoadControlLimitDataUpdate(EgLpUseCase* self, const EventPayload* payload
 
   EebusError ret = EgLpGetActivePowerLimitInternal(self, entity_addr, &limit);
   if (ret == kEebusErrorOk) {
-    EG_LP_LISTENER_ON_POWER_LIMIT_RECEIVE(self->eg_lp_listener, &limit.value, &limit.duration, limit.is_active);
+    EG_LP_LISTENER_ON_POWER_LIMIT_RECEIVE(
+        self->eg_lp_listener,
+        entity_addr,
+        &limit.value,
+        &limit.duration,
+        limit.is_active
+    );
   }
 }
 
@@ -221,7 +227,7 @@ void OnConfigurationDataUpdate(const EgLpUseCase* self, const EventPayload* payl
     ScaledValue power_limit = {0};
     const EebusError err    = EgLpGetFailsafeActivePowerLimitInternal(self, entity_addr, &power_limit);
     if (err == kEebusErrorOk) {
-      EG_LP_LISTENER_ON_FAILSAFE_POWER_LIMIT_RECEIVE(self->eg_lp_listener, &power_limit);
+      EG_LP_LISTENER_ON_FAILSAFE_POWER_LIMIT_RECEIVE(self->eg_lp_listener, entity_addr, &power_limit);
     }
   }
 
@@ -234,7 +240,7 @@ void OnConfigurationDataUpdate(const EgLpUseCase* self, const EventPayload* payl
     const EebusError err  = EgLpGetFailsafeDurationMinimumInternal(self, entity_addr, &duration);
 
     if (err == kEebusErrorOk) {
-      EG_LP_LISTENER_ON_FAILSAFE_DURATION_RECEIVE(self->eg_lp_listener, &duration);
+      EG_LP_LISTENER_ON_FAILSAFE_DURATION_RECEIVE(self->eg_lp_listener, entity_addr, &duration);
     }
   }
 }
@@ -250,7 +256,8 @@ void OnHeartbeat(const EgLpUseCase* self, const EventPayload* payload) {
   }
 
   if (self->eg_lp_listener != NULL) {
-    EG_LP_LISTENER_ON_HEARTBEAT_RECEIVE(self->eg_lp_listener, *data->heartbeat_counter);
+    const EntityAddressType* const entity_addr = ENTITY_GET_ADDRESS(ENTITY_OBJECT(payload->entity));
+    EG_LP_LISTENER_ON_HEARTBEAT_RECEIVE(self->eg_lp_listener, entity_addr, *data->heartbeat_counter);
   }
 }
 

--- a/src/use_case/api/eg_lp_listener_interface.h
+++ b/src/use_case/api/eg_lp_listener_interface.h
@@ -36,13 +36,26 @@ struct EgLpListenerInterface {
   void (*on_remote_entity_disconnect)(EgLpListenerObject* self, const EntityAddressType* entity_addr);
   void (*on_power_limit_receive)(
       EgLpListenerObject* self,
+      const EntityAddressType* entity_addr,
       const ScaledValue* power_limit,
       const DurationType* duration,
       bool is_active
   );
-  void (*on_failsafe_power_limit_receive)(EgLpListenerObject* self, const ScaledValue* power_limit);
-  void (*on_failsafe_duration_receive)(EgLpListenerObject* self, const DurationType* duration);
-  void (*on_heartbeat_receive)(EgLpListenerObject* self, uint64_t heartbeat_counter);
+  void (*on_failsafe_power_limit_receive)(
+      EgLpListenerObject* self,
+      const EntityAddressType* entity_addr,
+      const ScaledValue* power_limit
+  );
+  void (*on_failsafe_duration_receive)(
+      EgLpListenerObject* self,
+      const EntityAddressType* entity_addr,
+      const DurationType* duration
+  );
+  void (*on_heartbeat_receive)(
+      EgLpListenerObject* self,
+      const EntityAddressType* entity_addr,
+      uint64_t heartbeat_counter
+  );
 };
 
 /**
@@ -82,26 +95,26 @@ struct EgLpListenerObject {
 /**
  * @brief EG LP Listener On Power Limit Receive caller definition
  */
-#define EG_LP_LISTENER_ON_POWER_LIMIT_RECEIVE(obj, power_limit, duration, is_active) \
-  (EG_LP_LISTENER_INTERFACE(obj)->on_power_limit_receive(obj, power_limit, duration, is_active))
+#define EG_LP_LISTENER_ON_POWER_LIMIT_RECEIVE(obj, entity_addr, power_limit, duration, is_active) \
+  (EG_LP_LISTENER_INTERFACE(obj)->on_power_limit_receive(obj, entity_addr, power_limit, duration, is_active))
 
 /**
  * @brief EG LP Listener On Failsafe Power Limit Receive caller definition
  */
-#define EG_LP_LISTENER_ON_FAILSAFE_POWER_LIMIT_RECEIVE(obj, power_limit) \
-  (EG_LP_LISTENER_INTERFACE(obj)->on_failsafe_power_limit_receive(obj, power_limit))
+#define EG_LP_LISTENER_ON_FAILSAFE_POWER_LIMIT_RECEIVE(obj, entity_addr, power_limit) \
+  (EG_LP_LISTENER_INTERFACE(obj)->on_failsafe_power_limit_receive(obj, entity_addr, power_limit))
 
 /**
  * @brief EG LP Listener On Failsafe Duration Receive caller definition
  */
-#define EG_LP_LISTENER_ON_FAILSAFE_DURATION_RECEIVE(obj, duration) \
-  (EG_LP_LISTENER_INTERFACE(obj)->on_failsafe_duration_receive(obj, duration))
+#define EG_LP_LISTENER_ON_FAILSAFE_DURATION_RECEIVE(obj, entity_addr, duration) \
+  (EG_LP_LISTENER_INTERFACE(obj)->on_failsafe_duration_receive(obj, entity_addr, duration))
 
 /**
  * @brief EG LP Listener On Heartbeat Receive caller definition
  */
-#define EG_LP_LISTENER_ON_HEARTBEAT_RECEIVE(obj, heartbeat_counter) \
-  (EG_LP_LISTENER_INTERFACE(obj)->on_heartbeat_receive(obj, heartbeat_counter))
+#define EG_LP_LISTENER_ON_HEARTBEAT_RECEIVE(obj, entity_addr, heartbeat_counter) \
+  (EG_LP_LISTENER_INTERFACE(obj)->on_heartbeat_receive(obj, entity_addr, heartbeat_counter))
 
 #ifdef __cplusplus
 }

--- a/tests/src/mocks/use_case/api/eg_lp_listener_mock.cpp
+++ b/tests/src/mocks/use_case/api/eg_lp_listener_mock.cpp
@@ -14,13 +14,20 @@ static void OnRemoteEntityConnect(EgLpListenerObject* self, const EntityAddressT
 static void OnRemoteEntityDisconnect(EgLpListenerObject* self, const EntityAddressType* entity_addr);
 static void OnPowerLimitReceive(
     EgLpListenerObject* self,
+    const EntityAddressType* entity_addr,
     const ScaledValue* power_limit,
     const DurationType* duration,
     bool is_active
 );
-static void OnFailsafePowerLimitReceive(EgLpListenerObject* self, const ScaledValue* power_limit);
-static void OnFailsafeDurationReceive(EgLpListenerObject* self, const DurationType* duration);
-static void OnHeartbeatReceive(EgLpListenerObject* self, uint64_t heartbeat_counter);
+static void OnFailsafePowerLimitReceive(
+    EgLpListenerObject* self,
+    const EntityAddressType* entity_addr,
+    const ScaledValue* power_limit
+);
+static void
+OnFailsafeDurationReceive(EgLpListenerObject* self, const EntityAddressType* entity_addr, const DurationType* duration);
+static void
+OnHeartbeatReceive(EgLpListenerObject* self, const EntityAddressType* entity_addr, uint64_t heartbeat_counter);
 
 static const EgLpListenerInterface eg_lp_listener_methods = {
     .destruct                        = Destruct,
@@ -78,6 +85,7 @@ void OnRemoteEntityDisconnect(EgLpListenerObject* self, const EntityAddressType*
 
 void OnPowerLimitReceive(
     EgLpListenerObject* self,
+    const EntityAddressType* entity_addr,
     const ScaledValue* power_limit,
     const DurationType* duration,
     bool is_active
@@ -86,17 +94,25 @@ void OnPowerLimitReceive(
   mock->gmock->OnPowerLimitReceive(self, power_limit, duration, is_active);
 }
 
-void OnFailsafePowerLimitReceive(EgLpListenerObject* self, const ScaledValue* power_limit) {
+void OnFailsafePowerLimitReceive(
+    EgLpListenerObject* self,
+    const EntityAddressType* entity_addr,
+    const ScaledValue* power_limit
+) {
   EgLpListenerMock* const mock = EG_LP_LISTENER_MOCK(self);
   mock->gmock->OnFailsafePowerLimitReceive(self, power_limit);
 }
 
-void OnFailsafeDurationReceive(EgLpListenerObject* self, const DurationType* duration) {
+void OnFailsafeDurationReceive(
+    EgLpListenerObject* self,
+    const EntityAddressType* entity_addr,
+    const DurationType* duration
+) {
   EgLpListenerMock* const mock = EG_LP_LISTENER_MOCK(self);
   mock->gmock->OnFailsafeDurationReceive(self, duration);
 }
 
-void OnHeartbeatReceive(EgLpListenerObject* self, uint64_t heartbeat_counter) {
+void OnHeartbeatReceive(EgLpListenerObject* self, const EntityAddressType* entity_addr, uint64_t heartbeat_counter) {
   EgLpListenerMock* const mock = EG_LP_LISTENER_MOCK(self);
   mock->gmock->OnHeartbeatReceive(self, heartbeat_counter);
 }


### PR DESCRIPTION
This PR adds the concerned entity address to the following EG LPC event handlers:
- on_power_limit_receive
- on_failsafe_power_limit_receive
- on_failsafe_duration_receive
- on_heartbeat_receive

It stays inline with the event handlers of MA MPC and allows each handler to know the origin entity of the event.