### PR TITLE
ship(websocket_client): add ssl cipher list to lws context

### DIFF
--- a/src/ship/websocket/websocket_client.c
+++ b/src/ship/websocket/websocket_client.c
@@ -177,6 +177,11 @@ struct lws_context* WebsocketClientLwsContextCreate(WebsocketClient* self) {
       .fd_limit_per_thread = kFdLmitPerThread,
       .options = LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT | LWS_SERVER_OPTION_H2_JUST_FIX_WINDOW_UPDATE_OVERFLOW,
 
+      .client_ssl_cipher_list
+      = "ECDHE-ECDSA-AES128-GCM-SHA256:"
+        "ECDHE-ECDSA-AES128-CCM8:"
+        "ECDHE-ECDSA-AES128-SHA256",
+
       .client_ssl_cert_mem     = TLS_CERTIFICATE_GET_CERTIFICATE(self->tls_cert),
       .client_ssl_cert_mem_len = (unsigned int)TLS_CERTIFICATE_GET_CERTIFICATE_SIZE(self->tls_cert),
       .client_ssl_key_mem      = TLS_CERTIFICATE_GET_PRIVATE_KEY(self->tls_cert),


### PR DESCRIPTION
If the websocket client ssl cipher list is not provided some servers will reject the connection immediately.

```
[2026/05/13 07:46:26:5417] I: reason: tls: error:0A000410:SSL routines::ssl/tls alert handshake failure
```

This PR specifies the ssl cipher list for the websocket client.
It is the same list as the http server.