### PR TITLE
Fix use-after-free in the FreeRTOS mDNS backend

### DIFF
--- a/src/common/eebus_malloc.h
+++ b/src/common/eebus_malloc.h
@@ -22,7 +22,7 @@
 #define SRC_COMMON_EEBUS_MALLOC_H_
 
 #if defined(__freertos__)
-#include <FreeRTOS.h>
+#include <freertos/FreeRTOS.h>
 
 #define EEBUS_MALLOC(size) pvPortMalloc((size))
 #define EEBUS_FREE(size) vPortFree((size))

--- a/src/ship/mdns/ship_mdns_bonjour.c
+++ b/src/ship/mdns/ship_mdns_bonjour.c
@@ -92,7 +92,6 @@
 #include "src/common/vector.h"
 #include "src/ship/api/mdns_entry.h"
 #include "src/ship/api/ship_mdns_interface.h"
-#include "src/ship/ship_connection/types.h"
 
 /** Set MDNS_DEBUG 1 to enable debug prints */
 #ifndef MDNS_DEBUG

--- a/src/ship/mdns/ship_mdns_freertos.c
+++ b/src/ship/mdns/ship_mdns_freertos.c
@@ -87,6 +87,7 @@ static void Stop(ShipMdnsObject* self);
 static EebusError RegisterService(ShipMdnsObject* self);
 static void DeregisterService(ShipMdnsObject* self);
 static void SetAutoaccept(ShipMdnsObject* self, bool autoaccept);
+static void MdnsNotifyFoundEntries(Mdns* mdns);
 
 static const ShipMdnsInterface mdns_methods = {
     .destruct           = Destruct,
@@ -217,6 +218,20 @@ void MdnsQueryNotifyCallback(mdns_search_once_t* search) {
   xSemaphoreGive(mdns->semaphore);
 }
 
+static void MdnsNotifyFoundEntries(Mdns* mdns) {
+  const size_t found_count = VectorGetSize(mdns->found_entries);
+  Vector* const copy       = VectorCreateWithDeallocator(MdnsEntryDeallocator);
+
+  for (size_t i = 0; i < found_count; ++i) {
+    MdnsEntry* const entry = (MdnsEntry*)VectorGetElement(mdns->found_entries, i);
+    if (entry != NULL) {
+      VectorPushBack(copy, MdnsEntryCopy(entry));
+    }
+  }
+
+  mdns->on_entries_found_cb(copy, mdns->context);
+}
+
 void MdnsProcessSearchResult(Mdns* mdns, mdns_search_once_t* search) {
   mdns_result_t* results = NULL;
 
@@ -251,8 +266,7 @@ void MdnsProcessSearchResult(Mdns* mdns, mdns_search_once_t* search) {
   }
 
   mdns_query_results_free(results);
-
-  mdns->on_entries_found_cb(mdns->found_entries, mdns->context);
+  MdnsNotifyFoundEntries(mdns);
 }
 
 uint32_t GetUpdateIntervalMs(void) {


### PR DESCRIPTION
Issue:
When an mdns search finished, the FreeRTOS backend passed its own `found_entries` vector straight to the `on_entries_found` callback. But that callback takes ownership: it processes entries and frees the vector. So the mdns backend kept using a vector that had already been freed.

Fix:
Add `MdnsNotifyFoundEntries()` which copies the entries into a new vector and passes that to the ship_node callback (the same approach used in `ship_mdns_bonjour.c`)

Other updates:
Remove unused include from `src/ship/mdns/ship_mdns_bonjour.c`
Fix `FreeRTOS.h` include in `src/common/eebus_malloc.h`