### PR TITLE
ship_mdns_freertos: support Ethernet (W5500/ETH_DEF) and shared mDNS daemon

### DIFF
--- a/src/ship/mdns/ship_mdns_freertos.c
+++ b/src/ship/mdns/ship_mdns_freertos.c
@@ -16,6 +16,12 @@
 /**
  * @file
  * @brief FreeRTOS specific Mdns implementation
+ *
+ * Patched for ESPHome HEMS (W5500 SPI Ethernet):
+ *  - mdns_init() is allowed to return ESP_ERR_INVALID_STATE (already
+ *    initialized by ESPHome's API/mDNS component).
+ *  - Netif lookup tries WIFI_STA_DEF → ETH_DEF → any UP netif, because
+ *    the device uses W5500 SPI Ethernet, not WiFi.
  */
 
 #include "mdns.h"
@@ -349,15 +355,37 @@ EebusError RegisterService(ShipMdnsObject* self) {
 EebusError Start(ShipMdnsObject* self) {
   Mdns* const mdns = MDNS(self);
 
+  /* mdns_init() may return ESP_ERR_INVALID_STATE when ESPHome's API/mDNS
+   * component has already initialised mDNS — that is fine, reuse it. */
   esp_err_t err = mdns_init();
-  if (err != ESP_OK) {
+  if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
     MDNS_DEBUG_PRINTF("mdns_init() failed: %d\n", err);
     return kEebusErrorInit;
   }
 
-  esp_netif_t* netif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+  /* Locate the active netif.  Try WiFi STA first (original assumption),
+   * then fall back to the default Ethernet interface (ETH_DEF) which is
+   * what the W5500 SPI Ethernet driver registers.  If neither key matches
+   * (custom netif keys), walk all registered netifs for the first UP one. */
+  static const char* const kNetifKeys[] = {
+      "WIFI_STA_DEF",   /* WiFi station */
+      "ETH_DEF",        /* SPI / RMII Ethernet (W5500 / LAN87xx / …) */
+  };
+  esp_netif_t* netif = NULL;
+  for (size_t i = 0; i < sizeof(kNetifKeys) / sizeof(kNetifKeys[0]); i++) {
+    netif = esp_netif_get_handle_from_ifkey(kNetifKeys[i]);
+    if (netif != NULL) break;
+  }
   if (netif == NULL) {
-    MDNS_DEBUG_PRINTF("esp_netif_get_handle_from_ifkey() failed\n");
+    /* Last resort: walk the netif list for any UP interface */
+    netif = esp_netif_next_unsafe(NULL);
+    while (netif != NULL) {
+      if (esp_netif_is_netif_up(netif)) break;
+      netif = esp_netif_next_unsafe(netif);
+    }
+  }
+  if (netif == NULL) {
+    MDNS_DEBUG_PRINTF("No suitable netif found (WIFI_STA_DEF, ETH_DEF, any UP)\n");
     return kEebusErrorInit;
   }
 

--- a/src/ship/mdns/ship_mdns_freertos.c
+++ b/src/ship/mdns/ship_mdns_freertos.c
@@ -17,9 +17,8 @@
  * @file
  * @brief FreeRTOS specific Mdns implementation
  *
- * Patched to support WiFi (WIFI_STA_DEF) and Ethernet (ETH_DEF / W5500)
- * netifs, and to tolerate ESP_ERR_INVALID_STATE from mdns_init() when
- * mDNS is already initialized by the host framework.
+ * Supported netifs: WiFi station (WIFI_STA_DEF) and Ethernet
+ * (ETH_DEF — covers W5500 SPI, RMII Ethernet, and similar drivers).
  */
 
 #include "mdns.h"
@@ -351,29 +350,33 @@ EebusError RegisterService(ShipMdnsObject* self) {
 }
 
 static esp_netif_t* MdnsGetEspNetif(Mdns* self) {
-  (void)self;
+  UNUSED(self);
+
   // Locate the active netif. Try WiFi STA first (original assumption),
   // then fall back to the default Ethernet interface (ETH_DEF) which is
   // what the W5500 SPI Ethernet driver registers. If neither key matches
   // (custom netif keys), walk all registered netifs for the first UP one.
   static const char* const kNetifKeys[] = {
-      "WIFI_STA_DEF",   /* WiFi station */
-      "ETH_DEF",        /* SPI / RMII Ethernet (W5500 / LAN87xx / …) */
+      "WIFI_STA_DEF",  // WiFi station
+      "ETH_DEF",       // SPI / RMII Ethernet (W5500 / LAN87xx / ...)
   };
+
   esp_netif_t* netif = NULL;
   for (size_t i = 0; i < ARRAY_SIZE(kNetifKeys); i++) {
     netif = esp_netif_get_handle_from_ifkey(kNetifKeys[i]);
-    if (netif != NULL) break;
-  }
-
-  if (netif == NULL) {
-    // Last resort: walk the netif list for any UP interface.
-    netif = esp_netif_next_unsafe(NULL);
-    while (netif != NULL) {
-      if (esp_netif_is_netif_up(netif)) { break; }
-      netif = esp_netif_next_unsafe(netif);
+    if (netif != NULL) {
+      return netif;
     }
   }
+
+  // Last resort: walk the netif list for any UP interface.
+  netif = NULL;
+  while ((netif = esp_netif_next_unsafe(netif)) != NULL) {
+    if (esp_netif_is_netif_up(netif)) {
+      return netif;
+    }
+  }
+
   return netif;
 }
 

--- a/src/ship/mdns/ship_mdns_freertos.c
+++ b/src/ship/mdns/ship_mdns_freertos.c
@@ -17,11 +17,9 @@
  * @file
  * @brief FreeRTOS specific Mdns implementation
  *
- * Patched for ESPHome HEMS (W5500 SPI Ethernet):
- *  - mdns_init() is allowed to return ESP_ERR_INVALID_STATE (already
- *    initialized by ESPHome's API/mDNS component).
- *  - Netif lookup tries WIFI_STA_DEF → ETH_DEF → any UP netif, because
- *    the device uses W5500 SPI Ethernet, not WiFi.
+ * Patched to support WiFi (WIFI_STA_DEF) and Ethernet (ETH_DEF / W5500)
+ * netifs, and to tolerate ESP_ERR_INVALID_STATE from mdns_init() when
+ * mDNS is already initialized by the host framework.
  */
 
 #include "mdns.h"
@@ -352,38 +350,45 @@ EebusError RegisterService(ShipMdnsObject* self) {
   return kEebusErrorOk;
 }
 
+static esp_netif_t* MdnsGetEspNetif(Mdns* self) {
+  (void)self;
+  // Locate the active netif. Try WiFi STA first (original assumption),
+  // then fall back to the default Ethernet interface (ETH_DEF) which is
+  // what the W5500 SPI Ethernet driver registers. If neither key matches
+  // (custom netif keys), walk all registered netifs for the first UP one.
+  static const char* const kNetifKeys[] = {
+      "WIFI_STA_DEF",   /* WiFi station */
+      "ETH_DEF",        /* SPI / RMII Ethernet (W5500 / LAN87xx / …) */
+  };
+  esp_netif_t* netif = NULL;
+  for (size_t i = 0; i < ARRAY_SIZE(kNetifKeys); i++) {
+    netif = esp_netif_get_handle_from_ifkey(kNetifKeys[i]);
+    if (netif != NULL) break;
+  }
+
+  if (netif == NULL) {
+    // Last resort: walk the netif list for any UP interface.
+    netif = esp_netif_next_unsafe(NULL);
+    while (netif != NULL) {
+      if (esp_netif_is_netif_up(netif)) { break; }
+      netif = esp_netif_next_unsafe(netif);
+    }
+  }
+  return netif;
+}
+
 EebusError Start(ShipMdnsObject* self) {
   Mdns* const mdns = MDNS(self);
 
-  /* mdns_init() may return ESP_ERR_INVALID_STATE when ESPHome's API/mDNS
-   * component has already initialised mDNS — that is fine, reuse it. */
+  // mdns_init() may return ESP_ERR_INVALID_STATE when the host framework has
+  // already initialized mDNS — that is fine, reuse it.
   esp_err_t err = mdns_init();
   if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
     MDNS_DEBUG_PRINTF("mdns_init() failed: %d\n", err);
     return kEebusErrorInit;
   }
 
-  /* Locate the active netif.  Try WiFi STA first (original assumption),
-   * then fall back to the default Ethernet interface (ETH_DEF) which is
-   * what the W5500 SPI Ethernet driver registers.  If neither key matches
-   * (custom netif keys), walk all registered netifs for the first UP one. */
-  static const char* const kNetifKeys[] = {
-      "WIFI_STA_DEF",   /* WiFi station */
-      "ETH_DEF",        /* SPI / RMII Ethernet (W5500 / LAN87xx / …) */
-  };
-  esp_netif_t* netif = NULL;
-  for (size_t i = 0; i < sizeof(kNetifKeys) / sizeof(kNetifKeys[0]); i++) {
-    netif = esp_netif_get_handle_from_ifkey(kNetifKeys[i]);
-    if (netif != NULL) break;
-  }
-  if (netif == NULL) {
-    /* Last resort: walk the netif list for any UP interface */
-    netif = esp_netif_next_unsafe(NULL);
-    while (netif != NULL) {
-      if (esp_netif_is_netif_up(netif)) break;
-      netif = esp_netif_next_unsafe(netif);
-    }
-  }
+  esp_netif_t* netif = MdnsGetEspNetif(mdns);
   if (netif == NULL) {
     MDNS_DEBUG_PRINTF("No suitable netif found (WIFI_STA_DEF, ETH_DEF, any UP)\n");
     return kEebusErrorInit;


### PR DESCRIPTION
## Problem

Two separate issues prevent `ship_mdns_freertos.c` from working on ESP32 boards with SPI/RMII Ethernet (W5500, LAN87xx, etc.) or when the mDNS daemon is shared with another framework (e.g. ESPHome).

### 1. `mdns_init()` fails with `ESP_ERR_INVALID_STATE`

When ESPHome's API server — or any other component — has already called `mdns_init()`, a second call returns `ESP_ERR_INVALID_STATE`.  The existing code treats this as fatal and returns `kEebusErrorInit`, so the SHIP mDNS service never starts.

### 2. Netif lookup hard-coded to `"WIFI_STA_DEF"`

`esp_netif_get_handle_from_ifkey("WIFI_STA_DEF")` returns `NULL` on any board that doesn't have a WiFi station interface (pure-Ethernet, Thread, etc.).  The function then fails immediately with `kEebusErrorInit`, so openeebus never announces itself via mDNS and never discovers remote SHIP services.

On W5500 SPI Ethernet the interface key is `"ETH_DEF"` (registered by the ESP-IDF W5500 driver).

## Fix

**Fix 1** — tolerate `ESP_ERR_INVALID_STATE` from `mdns_init()` and reuse the already-running daemon.

**Fix 2** — probe interface keys in order: `"WIFI_STA_DEF"` → `"ETH_DEF"` → walk all registered netifs for the first UP one.  This covers WiFi, W5500/RMII Ethernet, and custom netif configurations without breaking any existing behaviour.

## Scope

All changes are confined to the `Start()` function in `src/ship/mdns/ship_mdns_freertos.c`.  No API or header changes.

## Testing

Verified on an ESP32-S3 with W5500 SPI Ethernet (POE) running ESPHome.  Without this fix mDNS announcements and discovery both fail silently.  With the fix, `_ship._tcp` is correctly announced and remote SHIP services are discovered.