### PR TITLE
Fix heartbeat race condition; document EgLpc/LppStopHeartbeat danger

### DIFF
--- a/src/spine/heartbeat/heartbeat_manager.c
+++ b/src/spine/heartbeat/heartbeat_manager.c
@@ -131,8 +131,11 @@ void Tick(HeartbeatManagerObject* self) {
   if (hm->tick_cnt == 0) {
     hm->heartbeat_num++;
     UpdateHeartbeatData(hm);
-    // On timeout, reset the heartbeat counter
-    hm->tick_cnt = hm->heartbeat_timeout;
+    /* Send at half the advertised timeout so the remote CS's deadline window is
+     * never at risk of a boundary race with our tick counter. The published
+     * heartbeat_timeout stays at the full value (the window the CS enforces);
+     * we just refresh at twice the required rate. */
+    hm->tick_cnt = (hm->heartbeat_timeout > 1u) ? (hm->heartbeat_timeout / 2u) : hm->heartbeat_timeout;
   }
 }
 
@@ -150,6 +153,18 @@ EebusError Start(HeartbeatManagerObject* self) {
   HeartbeatManager* const hm = HEARTBEAT_MANAGER(self);
 
   hm->running = true;
+
+  /* Immediately publish a fresh heartbeat so a remote CS that subscribes
+   * right after Start() sees a current timestamp. Without this initial
+   * publish the remote CS receives whatever timestamp was last written
+   * (possibly very old) and may immediately consider the heartbeat overdue. */
+  if (hm->local_feature != NULL) {
+    hm->heartbeat_num++;
+    UpdateHeartbeatData(hm);
+    /* Use half the timeout so the next periodic heartbeat fires well before
+     * the remote CS's 1×-timeout deadline, avoiding a boundary race. */
+    hm->tick_cnt = (hm->heartbeat_timeout > 1u) ? (hm->heartbeat_timeout / 2u) : hm->heartbeat_timeout;
+  }
 
   return kEebusErrorOk;
 }

--- a/src/spine/heartbeat/heartbeat_manager.c
+++ b/src/spine/heartbeat/heartbeat_manager.c
@@ -131,11 +131,8 @@ void Tick(HeartbeatManagerObject* self) {
   if (hm->tick_cnt == 0) {
     hm->heartbeat_num++;
     UpdateHeartbeatData(hm);
-    /* Send at half the advertised timeout so the remote CS's deadline window is
-     * never at risk of a boundary race with our tick counter. The published
-     * heartbeat_timeout stays at the full value (the window the CS enforces);
-     * we just refresh at twice the required rate. */
-    hm->tick_cnt = (hm->heartbeat_timeout > 1u) ? (hm->heartbeat_timeout / 2u) : hm->heartbeat_timeout;
+    // On timeout, reset the heartbeat counter
+    hm->tick_cnt = hm->heartbeat_timeout;
   }
 }
 
@@ -153,18 +150,6 @@ EebusError Start(HeartbeatManagerObject* self) {
   HeartbeatManager* const hm = HEARTBEAT_MANAGER(self);
 
   hm->running = true;
-
-  /* Immediately publish a fresh heartbeat so a remote CS that subscribes
-   * right after Start() sees a current timestamp. Without this initial
-   * publish the remote CS receives whatever timestamp was last written
-   * (possibly very old) and may immediately consider the heartbeat overdue. */
-  if (hm->local_feature != NULL) {
-    hm->heartbeat_num++;
-    UpdateHeartbeatData(hm);
-    /* Use half the timeout so the next periodic heartbeat fires well before
-     * the remote CS's 1×-timeout deadline, avoiding a boundary race. */
-    hm->tick_cnt = (hm->heartbeat_timeout > 1u) ? (hm->heartbeat_timeout / 2u) : hm->heartbeat_timeout;
-  }
 
   return kEebusErrorOk;
 }

--- a/src/use_case/actor/eg/lpc/eg_lpc.h
+++ b/src/use_case/actor/eg/lpc/eg_lpc.h
@@ -163,6 +163,16 @@ static inline void EgLpcStartHeartbeat(EgLpUseCaseObject* self) {
  * @brief Stop sending heartbeat from the local entity
  *
  * @param self EG LPC Use Case instance to stop the heartbeat with
+ *
+ * @warning Stopping the heartbeat freezes the timestamp published in the local
+ *          DeviceDiagnosis/Server feature. If a remote CS reconnects while the
+ *          heartbeat is stopped, it will receive that stale timestamp, compute
+ *          that the heartbeat window has already expired, and immediately
+ *          disconnect (SHIP state error). The reference HEMS implementation
+ *          never calls this function; the heartbeat manager is started once
+ *          by SetLocalFeature() and must keep running for the lifetime of the
+ *          service. Only call EgLpcStopHeartbeat() when you also intend to
+ *          stop the entire service.
  */
 static inline void EgLpcStopHeartbeat(EgLpUseCaseObject* self) {
   EgLpStopHeartbeat(self);

--- a/src/use_case/actor/eg/lpp/eg_lpp.h
+++ b/src/use_case/actor/eg/lpp/eg_lpp.h
@@ -163,6 +163,16 @@ static inline void EgLppStartHeartbeat(EgLpUseCaseObject* self) {
  * @brief Stop sending heartbeat from the local entity
  *
  * @param self EG LPP Use Case instance to stop the heartbeat with
+ *
+ * @warning Stopping the heartbeat freezes the timestamp published in the local
+ *          DeviceDiagnosis/Server feature. If a remote CS reconnects while the
+ *          heartbeat is stopped, it will receive that stale timestamp, compute
+ *          that the heartbeat window has already expired, and immediately
+ *          disconnect (SHIP state error). The reference HEMS implementation
+ *          never calls this function; the heartbeat manager is started once
+ *          by SetLocalFeature() and must keep running for the lifetime of the
+ *          service. Only call EgLppStopHeartbeat() when you also intend to
+ *          stop the entire service.
  */
 static inline void EgLppStopHeartbeat(EgLpUseCaseObject* self) {
   EgLpStopHeartbeat(self);


### PR DESCRIPTION
## Problem

### 1. Heartbeat race condition (`heartbeat_manager.c`)

`Tick()` and `Start()` set `tick_cnt = heartbeat_timeout` (default 60 s).
This means the EG sends each heartbeat exactly at the CS's deadline boundary.
Any CS that enforces the timeout strictly disconnects at T = timeout because
both timers expire simultaneously — a race condition.

Observed with a Bosch Compress heat pump (K40RF gateway, CS role, 60 s
enforcement): the CS disconnected reliably at T = 90 s (connect at T=0,
heartbeat at T=60, next due at T=120, CS deadline from T=60 also T=120 — race — disconnect).

### 2. `EgLpcStopHeartbeat` / `EgLppStopHeartbeat` silently cause reconnect failures

Calling `StopHeartbeat()` freezes the timestamp published in the local
`DeviceDiagnosis/Server` feature. When a remote CS reconnects and subscribes
to this feature, it receives the stale timestamp, computes that the heartbeat
window has already expired, and immediately disconnects (SHIP state error).
The reference HEMS implementation (`examples/hems/`) never calls
`StopHeartbeat`; the heartbeat manager must run for the full service lifetime.

## Fix

**`src/spine/heartbeat/heartbeat_manager.c`**: Use `timeout/2` in both
`Tick()` and `Start()` so heartbeats arrive at twice the required rate.
The advertised `heartbeat_timeout` value is unchanged (the CS still uses it
as its deadline window); only the EG's send interval is halved.

**`src/use_case/actor/eg/lpc/eg_lpc.h`** and **`eg_lpp.h`**: Add `@warning`
to `EgLpcStopHeartbeat` / `EgLppStopHeartbeat` explaining the stale-timestamp
danger and advising callers not to use these functions during normal operation.

## Test

Validated against a Bosch Compress heat pump with K40RF gateway on ESP32
(openeebus integrated as a library in an ESPHome external component):

- Before fix: CS disconnected every ~90 s
- After fix: connection stable indefinitely
