### PR TITLE
eg_lpc/lpp: re-enable mandatory scenario 3 (DeviceDiagnosis)

### DIFF
--- a/src/use_case/actor/eg/lpc/eg_lpc.c
+++ b/src/use_case/actor/eg/lpc/eg_lpc.c
@@ -38,9 +38,7 @@ static const EntityTypeType valid_entity_types[]  = {
 
 static const FeatureTypeType use_case_scenario_support_1_features[] = {kFeatureTypeTypeLoadControl};
 static const FeatureTypeType use_case_scenario_support_2_features[] = {kFeatureTypeTypeDeviceConfiguration};
-#if 0
 static const FeatureTypeType use_case_scenario_support_3_features[] = {kFeatureTypeTypeDeviceDiagnosis};
-#endif
 static const FeatureTypeType use_case_scenario_support_4_features[] = {kFeatureTypeTypeElectricalConnection};
 
 static const UseCaseScenario use_case_scenarios[] = {
@@ -56,14 +54,12 @@ static const UseCaseScenario use_case_scenarios[] = {
      .server_features      = use_case_scenario_support_2_features,
      .server_features_size = ARRAY_SIZE(use_case_scenario_support_2_features),
      },
-#if 0
     {
      .scenario             = (UseCaseScenarioSupportType)3,
      .mandatory            = true,
      .server_features      = use_case_scenario_support_3_features,
      .server_features_size = ARRAY_SIZE(use_case_scenario_support_3_features),
      },
-#endif
     {
      .scenario             = (UseCaseScenarioSupportType)4,
      .mandatory            = false,

--- a/src/use_case/actor/eg/lpp/eg_lpp.c
+++ b/src/use_case/actor/eg/lpp/eg_lpp.c
@@ -36,9 +36,7 @@ static const EntityTypeType valid_entity_types[]  = {
 
 static const FeatureTypeType use_case_scenario_support_1_features[] = {kFeatureTypeTypeLoadControl};
 static const FeatureTypeType use_case_scenario_support_2_features[] = {kFeatureTypeTypeDeviceConfiguration};
-#if 0
 static const FeatureTypeType use_case_scenario_support_3_features[] = {kFeatureTypeTypeDeviceDiagnosis};
-#endif
 static const FeatureTypeType use_case_scenario_support_4_features[] = {kFeatureTypeTypeElectricalConnection};
 
 static const UseCaseScenario use_case_scenarios[] = {
@@ -54,14 +52,12 @@ static const UseCaseScenario use_case_scenarios[] = {
      .server_features      = use_case_scenario_support_2_features,
      .server_features_size = ARRAY_SIZE(use_case_scenario_support_2_features),
      },
-#if 0
     {
      .scenario             = (UseCaseScenarioSupportType)3,
      .mandatory            = true,
      .server_features      = use_case_scenario_support_3_features,
      .server_features_size = ARRAY_SIZE(use_case_scenario_support_3_features),
      },
-#endif
     {
      .scenario             = (UseCaseScenarioSupportType)4,
      .mandatory            = false,

--- a/tests/src/use_case/actor/eg/lpc/send/use_case_data_reply.inc
+++ b/tests/src/use_case/actor/eg/lpc/send/use_case_data_reply.inc
@@ -90,6 +90,7 @@ static constexpr char use_case_data_reply[] = R"({
                                 "scenarioSupport": [
                                   1,
                                   2,
+                                  3,
                                   4
                                 ]
                               },

--- a/tests/src/use_case/actor/eg/lpp/send/use_case_data_reply.inc
+++ b/tests/src/use_case/actor/eg/lpp/send/use_case_data_reply.inc
@@ -90,6 +90,7 @@ static constexpr char use_case_data_reply[] = R"({
                                 "scenarioSupport": [
                                   1,
                                   2,
+                                  3,
                                   4
                                 ]
                               },


### PR DESCRIPTION
## Summary

- Scenario 3 (`DeviceDiagnosis`) was inadvertently left disabled via `#if 0` guards in both `eg_lpc.c` and `eg_lpp.c`.
- Per **EEBus_UC_TS_LimitationOfPowerConsumption V1.0.0** and the Go reference implementation ([eebus-go](https://github.com/enbility/eebus-go)), DeviceDiagnosis is a **mandatory scenario** for EG LPC/LPP.
- Controllable systems (tested with **Bosch Compress 5800i / K40RF gateway**) read the `NodeManagementDetailedDiscovery` from the Energy Guard and require all mandatory scenarios to be announced before displaying the connection as active. With scenario 3 absent, the K40RF shows *"Keine Verbindung zum EEBUS"* despite a fully established SHIP/SPINE session. Re-enabling scenario 3 fixes this — the display changes to *"EEBus verbunden"*.

## What changed

- Removed `#if 0` / `#endif` blocks wrapping the `use_case_scenario_support_3_features` array and the scenario 3 entry in `use_case_scenarios[]` for both `eg_lpc.c` and `eg_lpp.c`.
- No logic changes; `OnEntityAddedHandleDeviceDiagnosis()` in `eg_lp_events.c` already subscribes to the remote DeviceDiagnosis feature and requests the heartbeat — this was simply not reflected in the use case announcement.

## Test plan

- [ ] Build with LPC use case; verify DeviceDiagnosis scenario 3 appears in SPINE NodeManagement discovery response
- [ ] Connect Bosch K40RF gateway — display should show "EEBus verbunden" without needing an active power limit write
- [ ] LPP equivalent fix in `eg_lpp.c` is symmetrical; apply the same validation for production-limiting CS devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)