### PR TITLE
heartbeat_manager: rename heartbeat timeout to heartbeat period

### DIFF
--- a/src/spine/entity/entity_local.c
+++ b/src/spine/entity/entity_local.c
@@ -106,7 +106,7 @@ static void EntityLocalConstruct(
     EntityTypeType type,
     const uint32_t* entity_id,
     size_t entity_id_size,
-    uint32_t heartbeat_timeout
+    uint32_t heartbeat_period
 );
 
 void EntityLocalConstruct(
@@ -115,7 +115,7 @@ void EntityLocalConstruct(
     EntityTypeType type,
     const uint32_t* entity_id,
     size_t entity_id_size,
-    uint32_t heartbeat_timeout
+    uint32_t heartbeat_period
 ) {
   EntityConstruct(ENTITY(self), type, DEVICE_GET_ADDRESS(DEVICE_OBJECT(device)), entity_id, entity_id_size);
   // Override "virtual functions table"
@@ -126,7 +126,7 @@ void EntityLocalConstruct(
 
   // Only needed if the entity address is not DeviceInformationEntityId
   if ((entity_id != NULL) && (entity_id[0] != DEVICE_INFORMATION_ENTITY_ID)) {
-    self->heartbeat_manager = HeartbeatManagerCreate(ENTITY_LOCAL_OBJECT(self), heartbeat_timeout);
+    self->heartbeat_manager = HeartbeatManagerCreate(ENTITY_LOCAL_OBJECT(self), heartbeat_period);
   } else {
     self->heartbeat_manager = NULL;
   }
@@ -137,14 +137,14 @@ EntityLocalObject* EntityLocalCreate(
     EntityTypeType type,
     const uint32_t* entity_id,
     size_t entity_id_size,
-    uint32_t heartbeat_timeout
+    uint32_t heartbeat_period
 ) {
   EntityLocal* const entity_local = (EntityLocal*)EEBUS_MALLOC(sizeof(EntityLocal));
   if (entity_local == NULL) {
     return NULL;
   }
 
-  EntityLocalConstruct(entity_local, device, type, entity_id, entity_id_size, heartbeat_timeout);
+  EntityLocalConstruct(entity_local, device, type, entity_id, entity_id_size, heartbeat_period);
 
   return ENTITY_LOCAL_OBJECT(entity_local);
 }

--- a/src/spine/entity/entity_local.h
+++ b/src/spine/entity/entity_local.h
@@ -32,7 +32,7 @@ extern "C" {
 #endif  // __cplusplus
 
 EntityLocalObject* EntityLocalCreate(DeviceLocalObject* device, EntityTypeType type, const uint32_t* entity_id,
-    size_t entity_id_size, uint32_t heartbeat_timeout);
+    size_t entity_id_size, uint32_t heartbeat_period);
 
 static inline void EntityLocalDelete(EntityLocalObject* entity_local) {
   if (entity_local != NULL) {

--- a/src/spine/entity/entity_local.h
+++ b/src/spine/entity/entity_local.h
@@ -31,8 +31,13 @@
 extern "C" {
 #endif  // __cplusplus
 
-EntityLocalObject* EntityLocalCreate(DeviceLocalObject* device, EntityTypeType type, const uint32_t* entity_id,
-    size_t entity_id_size, uint32_t heartbeat_period);
+EntityLocalObject* EntityLocalCreate(
+  DeviceLocalObject* device,
+  EntityTypeType type,
+  const uint32_t* entity_id,
+  size_t entity_id_size,
+  uint32_t heartbeat_period
+);
 
 static inline void EntityLocalDelete(EntityLocalObject* entity_local) {
   if (entity_local != NULL) {

--- a/src/spine/entity/entity_local.h
+++ b/src/spine/entity/entity_local.h
@@ -32,11 +32,11 @@ extern "C" {
 #endif  // __cplusplus
 
 EntityLocalObject* EntityLocalCreate(
-  DeviceLocalObject* device,
-  EntityTypeType type,
-  const uint32_t* entity_id,
-  size_t entity_id_size,
-  uint32_t heartbeat_period
+    DeviceLocalObject* device,
+    EntityTypeType type,
+    const uint32_t* entity_id,
+    size_t entity_id_size,
+    uint32_t heartbeat_period
 );
 
 static inline void EntityLocalDelete(EntityLocalObject* entity_local) {

--- a/src/spine/heartbeat/heartbeat_manager.c
+++ b/src/spine/heartbeat/heartbeat_manager.c
@@ -146,6 +146,8 @@ void UpdateHeartbeatData(HeartbeatManager* self) {
       .heartbeat_counter = &self->heartbeat_num,
       // The SPINE heartbeatTimeout wire field declares how often we send;
       // it is filled with the configured heartbeat period.
+      // TODO: consider a separate parameter for the declared heartbeatTimeout
+      // wire value so the send period and the declared timeout can differ
       .heartbeat_timeout = &(DurationType){.seconds = self->heartbeat_period},
   };
 

--- a/src/spine/heartbeat/heartbeat_manager.c
+++ b/src/spine/heartbeat/heartbeat_manager.c
@@ -39,7 +39,11 @@ struct HeartbeatManager {
   FeatureLocalObject* local_feature;
   uint64_t heartbeat_num;
   uint32_t tick_cnt;
-  uint32_t heartbeat_timeout;
+  // Period (in ticks/seconds) between two heartbeat transmissions.
+  // Note: this is not the remote heartbeat timeout (the deadline by which the
+  // remote expects a heartbeat); the application should choose
+  // heartbeat period <= remote heartbeat timeout.
+  uint32_t heartbeat_period;
 
   bool running;
 };
@@ -62,29 +66,25 @@ static const HeartbeatManagerInterface heartbeat_manager_methods = {
     .stop                 = Stop,
 };
 
-static void HeartbeatManagerConstruct(HeartbeatManager* self, EntityLocalObject* local_entity, uint32_t timeout);
+static void HeartbeatManagerConstruct(HeartbeatManager* self, EntityLocalObject* local_entity, uint32_t period);
 static void UpdateHeartbeatData(HeartbeatManager* self);
 
-// Send interval: 3/4 of the declared timeout so the remote always sees a fresh
-// heartbeat well before its deadline (which is typically 1× or 2× the declared timeout).
-#define HEARTBEAT_SEND_TICKS(timeout) ((3u * (timeout)) / 4u)
-
-void HeartbeatManagerConstruct(HeartbeatManager* self, EntityLocalObject* local_entity, uint32_t timeout) {
+void HeartbeatManagerConstruct(HeartbeatManager* self, EntityLocalObject* local_entity, uint32_t period) {
   // Override "virtual functions table"
   HEARTBEAT_MANAGER_INTERFACE(self) = &heartbeat_manager_methods;
 
-  self->local_entity      = local_entity;
-  self->local_feature     = NULL;
-  self->heartbeat_num     = 0;
-  self->tick_cnt          = HEARTBEAT_SEND_TICKS(timeout);
-  self->heartbeat_timeout = timeout;
-  self->running           = false;
+  self->local_entity     = local_entity;
+  self->local_feature    = NULL;
+  self->heartbeat_num    = 0;
+  self->tick_cnt         = period;
+  self->heartbeat_period = period;
+  self->running          = false;
 }
 
-HeartbeatManagerObject* HeartbeatManagerCreate(EntityLocalObject* local_entity, uint32_t timeout) {
+HeartbeatManagerObject* HeartbeatManagerCreate(EntityLocalObject* local_entity, uint32_t period) {
   HeartbeatManager* const heartbeat_manager = (HeartbeatManager*)EEBUS_MALLOC(sizeof(HeartbeatManager));
 
-  HeartbeatManagerConstruct(heartbeat_manager, local_entity, timeout);
+  HeartbeatManagerConstruct(heartbeat_manager, local_entity, period);
 
   return HEARTBEAT_MANAGER_OBJECT(heartbeat_manager);
 }
@@ -124,7 +124,7 @@ void SetLocalFeature(HeartbeatManagerObject* self, EntityLocalObject* entity, Fe
 void Tick(HeartbeatManagerObject* self) {
   HeartbeatManager* const hm = HEARTBEAT_MANAGER(self);
 
-  if (hm->heartbeat_timeout == 0) {
+  if (hm->heartbeat_period == 0) {
     return;
   }
 
@@ -135,7 +135,8 @@ void Tick(HeartbeatManagerObject* self) {
   if (hm->tick_cnt == 0) {
     hm->heartbeat_num++;
     UpdateHeartbeatData(hm);
-    hm->tick_cnt = HEARTBEAT_SEND_TICKS(hm->heartbeat_timeout);
+    // On period elapse, reset the heartbeat counter
+    hm->tick_cnt = hm->heartbeat_period;
   }
 }
 
@@ -143,7 +144,9 @@ void UpdateHeartbeatData(HeartbeatManager* self) {
   DeviceDiagnosisHeartbeatDataType heartbeat_data = {
       .timestamp         = &ABSOLUTE_OR_RELATIVE_TIME_NOW,
       .heartbeat_counter = &self->heartbeat_num,
-      .heartbeat_timeout = &(DurationType){.seconds = self->heartbeat_timeout},
+      // The SPINE heartbeatTimeout wire field declares how often we send;
+      // it is filled with the configured heartbeat period.
+      .heartbeat_timeout = &(DurationType){.seconds = self->heartbeat_period},
   };
 
   FEATURE_LOCAL_SET_DATA(self->local_feature, kFunctionTypeDeviceDiagnosisHeartbeatData, &heartbeat_data);

--- a/src/spine/heartbeat/heartbeat_manager.c
+++ b/src/spine/heartbeat/heartbeat_manager.c
@@ -65,6 +65,10 @@ static const HeartbeatManagerInterface heartbeat_manager_methods = {
 static void HeartbeatManagerConstruct(HeartbeatManager* self, EntityLocalObject* local_entity, uint32_t timeout);
 static void UpdateHeartbeatData(HeartbeatManager* self);
 
+// Send interval: 3/4 of the declared timeout so the remote always sees a fresh
+// heartbeat well before its deadline (which is typically 1× or 2× the declared timeout).
+#define HEARTBEAT_SEND_TICKS(timeout) ((3u * (timeout)) / 4u)
+
 void HeartbeatManagerConstruct(HeartbeatManager* self, EntityLocalObject* local_entity, uint32_t timeout) {
   // Override "virtual functions table"
   HEARTBEAT_MANAGER_INTERFACE(self) = &heartbeat_manager_methods;
@@ -72,7 +76,7 @@ void HeartbeatManagerConstruct(HeartbeatManager* self, EntityLocalObject* local_
   self->local_entity      = local_entity;
   self->local_feature     = NULL;
   self->heartbeat_num     = 0;
-  self->tick_cnt          = timeout;
+  self->tick_cnt          = HEARTBEAT_SEND_TICKS(timeout);
   self->heartbeat_timeout = timeout;
   self->running           = false;
 }
@@ -131,8 +135,7 @@ void Tick(HeartbeatManagerObject* self) {
   if (hm->tick_cnt == 0) {
     hm->heartbeat_num++;
     UpdateHeartbeatData(hm);
-    // On timeout, reset the heartbeat counter
-    hm->tick_cnt = hm->heartbeat_timeout;
+    hm->tick_cnt = HEARTBEAT_SEND_TICKS(hm->heartbeat_timeout);
   }
 }
 

--- a/src/spine/heartbeat/heartbeat_manager.h
+++ b/src/spine/heartbeat/heartbeat_manager.h
@@ -29,7 +29,10 @@
 extern "C" {
 #endif  // __cplusplus
 
-HeartbeatManagerObject* HeartbeatManagerCreate(EntityLocalObject* local_entity, uint32_t timeout);
+// period: interval in seconds between two heartbeat transmissions.
+// Choose heartbeat period <= the remote node's heartbeat timeout (its
+// deadline for receiving a heartbeat) so the remote always sees a fresh one.
+HeartbeatManagerObject* HeartbeatManagerCreate(EntityLocalObject* local_entity, uint32_t period);
 
 static inline void HeartbeatManagerDelete(HeartbeatManagerObject* heartbeat_manager) {
   if (heartbeat_manager != NULL) {


### PR DESCRIPTION
## Summary

Reworked per review feedback from @gennadiyvt (thanks for the proposal — implemented as suggested):

- The value passed to `EntityLocalCreate()` / `HeartbeatManagerCreate()` is now named `heartbeat period`: the interval between two heartbeat transmissions. It is used exactly as passed, without any math applied.
- `heartbeat timeout` remains the concept referring to the remote node's receive deadline. The application chooses `heartbeat period <= heartbeat timeout` (e.g. 45 or 55 seconds for a 60 second deadline) — the calculation stays on the application side.
- The previous 3/4 send-interval calculation inside the heartbeat manager is dropped.

No ABI change — only parameter/field renames plus documentation comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)