### PR TITLE
device_local: raise SPINE thread stack 4 KB -> 10 KB

### DIFF
--- a/src/spine/device/device_local.c
+++ b/src/spine/device/device_local.c
@@ -362,11 +362,11 @@ EebusError DeviceLocalTryStart(DeviceLocal* self) {
     return kEebusErrorMemory;
   }
 
-  // 12 KB: datagram processing runs use-case event handlers synchronously,
+  // 10 KB: datagram processing runs use-case event handlers synchronously,
   // which build and serialize reply datagrams via recursive cJSON calls -
   // 4 KB overflows the stack (observed on ESP32 while processing
   // nodeManagementUseCaseData and sending the DeviceDiagnosis subscription)
-  self->thread = EebusThreadCreate(DeviceLocalLoop, self, 12 * 1024);
+  self->thread = EebusThreadCreate(DeviceLocalLoop, self, 10 * 1024);
   if (self->thread == NULL) {
     DEVICE_LOCAL_DEBUG_PRINTF("%s(), start thread failed\n", __func__);
     return kEebusErrorThread;

--- a/src/spine/device/device_local.c
+++ b/src/spine/device/device_local.c
@@ -362,7 +362,11 @@ EebusError DeviceLocalTryStart(DeviceLocal* self) {
     return kEebusErrorMemory;
   }
 
-  self->thread = EebusThreadCreate(DeviceLocalLoop, self, 4 * 1024);
+  // 12 KB: datagram processing runs use-case event handlers synchronously,
+  // which build and serialize reply datagrams via recursive cJSON calls -
+  // 4 KB overflows the stack (observed on ESP32 while processing
+  // nodeManagementUseCaseData and sending the DeviceDiagnosis subscription)
+  self->thread = EebusThreadCreate(DeviceLocalLoop, self, 12 * 1024);
   if (self->thread == NULL) {
     DEVICE_LOCAL_DEBUG_PRINTF("%s(), start thread failed\n", __func__);
     return kEebusErrorThread;


### PR DESCRIPTION
## Problem

On ESP32, processing a `nodeManagementUseCaseData` reply crashes the SPINE thread with a FreeRTOS stack overflow (`vApplicationStackOverflowHook` panic). Datagram processing runs use-case event handlers synchronously on the same stack, and those handlers build and serialize new datagrams (for example, the DeviceDiagnosis subscription and heartbeat request) through recursive cJSON calls. The remote peer only observes a connection reset after the device reboots, which makes the root cause hard to find.

## Change

Raise the `DeviceLocalLoop` thread stack from 4 KB to 10 KB, as agreed in review.

ESP32-S3 high-water-mark measurements with the initial 12 KB build showed a worst observed peak of about 5.6 KB while processing `nodeManagementUseCaseData`. A 10 KB stack therefore retains about 4.4 KB of measured headroom while reducing reserved MCU memory by 2 KB per service instance compared with the initial proposal.

The original 12 KB build removed the previously reproducible crash during LPC use-case establishment and completed the full LPC flow. The 10 KB value follows the maintainer recommendation based on the measured peak. A reliable per-function stack-consumption ranking requires separate instrumentation and will be handled in a follow-up issue.