### PR TITLE
ship_node: implement CancelPairingWithSki

### DIFF
--- a/src/ship/ship_node/ship_node.c
+++ b/src/ship/ship_node/ship_node.c
@@ -756,11 +756,16 @@ void ShipNodeCancelPairingSki(ShipNodeObject* self, const char* ski) {
   }
   EEBUS_MUTEX_UNLOCK(sn->mutex);
 
-  // Close the connection belonging to that SKI (if it is the active one)
+  // Initiate the SHIP-level close for that SKI's connection. Do NOT run
+  // CloseShipConnection() here: if the connection already went down through
+  // the regular path, its remote-device structures are torn down and a second
+  // teardown crashes on dangling subscription links. The close handshake
+  // triggers HandleConnectionClosed exactly once for a live connection and
+  // is harmless for a dead one.
   if (sn->ship_connection != NULL) {
     const char* const conn_ski = SHIP_CONNECTION_GET_REMOTE_SKI(sn->ship_connection);
     if (SkiMatches(ski, conn_ski)) {
-      CloseShipConnection(sn, sn->ship_connection, false);
+      SHIP_CONNECTION_CLOSE_CONNECTION(sn->ship_connection, true, 0, "pairing cancelled");
     }
   }
 }

--- a/src/ship/ship_node/ship_node.c
+++ b/src/ship/ship_node/ship_node.c
@@ -747,26 +747,28 @@ void ShipNodeCancelPairingSki(ShipNodeObject* self, const char* ski) {
     return;
   }
 
-  // Forget the SKI if it is the one being cancelled so the slot becomes
-  // free for the intended device
+  ShipConnectionObject* sc = NULL;
+
   EEBUS_MUTEX_LOCK(sn->mutex);
   if (SkiMatches(ski, sn->remote_ski)) {
     StringDelete(sn->remote_ski);
     sn->remote_ski = NULL;
   }
-  EEBUS_MUTEX_UNLOCK(sn->mutex);
 
-  // Initiate the SHIP-level close for that SKI's connection. Do NOT run
-  // CloseShipConnection() here: if the connection already went down through
-  // the regular path, its remote-device structures are torn down and a second
-  // teardown crashes on dangling subscription links. The close handshake
-  // triggers HandleConnectionClosed exactly once for a live connection and
-  // is harmless for a dead one.
   if (sn->ship_connection != NULL) {
     const char* const conn_ski = SHIP_CONNECTION_GET_REMOTE_SKI(sn->ship_connection);
     if (SkiMatches(ski, conn_ski)) {
-      SHIP_CONNECTION_CLOSE_CONNECTION(sn->ship_connection, true, 0, "pairing cancelled");
+      sc = sn->ship_connection;
+
+      sn->ship_connection = NULL;
     }
+  }
+
+  EEBUS_MUTEX_UNLOCK(sn->mutex);
+
+  if (sc != NULL) {
+    SHIP_CONNECTION_CLOSE_CONNECTION(sc, true, 0, "pairing cancelled");
+    ShipConnectionDelete(sc);
   }
 }
 

--- a/src/ship/ship_node/ship_node.c
+++ b/src/ship/ship_node/ship_node.c
@@ -53,6 +53,7 @@ enum ShipNodeQueueMsgType {
   kShipNodeQueueMsgTypeShipUnregisterSki,
   kShipNodeQueueMsgTypeShipRegisterSki,
   kShipNodeQueueMsgTypeDiscardSuperseded,
+  kShipNodeQueueMsgTypeShipCancelPairingSki,
 };
 
 typedef enum ShipNodeQueueMsgType ShipNodeQueueMsgType;
@@ -88,6 +89,7 @@ static void RegisterRemoteSki(ShipNodeObject* self, const char* ski, bool is_tru
 static void UnregisterRemoteSki(ShipNodeObject* self, const char* ski);
 static void CancelPairingWithSki(ShipNodeObject* self, const char* ski);
 static void ShipNodeUnregisterSki(ShipNodeObject* self, const char* ski);
+static void ShipNodeCancelPairingSki(ShipNodeObject* self, const char* ski);
 static void ShipNodeRegisterSki(ShipNodeObject* self, const char* ski, bool is_trusted);
 
 static const ShipNodeInterface ship_node_methods = {
@@ -502,6 +504,8 @@ void* ShipNodeConnectionLoop(void* ctx) {
       ShipNodeConnectToRemoteSki(sn);
     } else if (queue_msg.type == kShipNodeQueueMsgTypeDiscardSuperseded) {
       CloseShipConnection(sn, queue_msg.ship_connection, queue_msg.had_error);
+    } else if (queue_msg.type == kShipNodeQueueMsgTypeShipCancelPairingSki) {
+      ShipNodeCancelPairingSki(SHIP_NODE_OBJECT(sn), queue_msg.ski);
     }
 
     ShipNodeQueueMsgDeallocator(&queue_msg);
@@ -735,8 +739,45 @@ void UnregisterRemoteSki(ShipNodeObject* self, const char* ski) {
   EEBUS_QUEUE_SEND(sn->msg_queue, &queue_msg, kTimeoutInfinite);
 }
 
+// Runs on the connection loop thread (same context as ShipNodeUnregisterSki)
+void ShipNodeCancelPairingSki(ShipNodeObject* self, const char* ski) {
+  ShipNode* const sn = SHIP_NODE(self);
+
+  if (StringIsEmpty(ski)) {
+    return;
+  }
+
+  // Forget the SKI if it is the one being cancelled so the slot becomes
+  // free for the intended device
+  EEBUS_MUTEX_LOCK(sn->mutex);
+  if (SkiMatches(ski, sn->remote_ski)) {
+    StringDelete(sn->remote_ski);
+    sn->remote_ski = NULL;
+  }
+  EEBUS_MUTEX_UNLOCK(sn->mutex);
+
+  // Close the connection belonging to that SKI (if it is the active one)
+  if (sn->ship_connection != NULL) {
+    const char* const conn_ski = SHIP_CONNECTION_GET_REMOTE_SKI(sn->ship_connection);
+    if (SkiMatches(ski, conn_ski)) {
+      CloseShipConnection(sn, sn->ship_connection, false);
+    }
+  }
+}
+
 void CancelPairingWithSki(ShipNodeObject* self, const char* ski) {
-  UNUSED(self);
-  UNUSED(ski);
-  // TODO: Implement method
+  ShipNode* const sn = SHIP_NODE(self);
+
+  if (StringIsEmpty(ski)) {
+    return;
+  }
+
+  ShipNodeQueueMessage queue_msg = {
+      .type            = kShipNodeQueueMsgTypeShipCancelPairingSki,
+      .ship_connection = NULL,
+      .had_error       = false,
+      .ski             = StringCopy(ski),
+  };
+
+  EEBUS_QUEUE_SEND(sn->msg_queue, &queue_msg, kTimeoutInfinite);
 }


### PR DESCRIPTION
## Problem

`ShipNode::CancelPairingWithSki()` was a TODO stub, so an application rejecting an unsolicited pairing attempt had no effect: the foreign connection stayed open, and an auto-trusted pairing candidate kept the registered SKI slot occupied — blocking the intended device from pairing.

## Change

Queue the cancellation to the connection loop thread (same execution context that `ShipNodeUnregisterSki` already uses) and there:
- forget the registered SKI if it is the one being cancelled (reverts an auto-trusted pairing-window candidate), and
- close the active connection if it belongs to that SKI.

Verified on ESP32 with several service instances: rejecting a foreign device now actually terminates its session and frees the pairing slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)