### PR TITLE
spine: scope the process-global event bus per device instance

### DIFF
--- a/src/spine/api/device_local_interface.h
+++ b/src/spine/api/device_local_interface.h
@@ -29,6 +29,7 @@
 #include "src/spine/api/device_interface.h"
 #include "src/spine/api/device_remote_interface.h"
 #include "src/spine/api/entity_local_interface.h"
+#include "src/spine/api/events_manager_interface.h"
 #include "src/spine/api/feature_local_interface.h"
 #include "src/spine/api/heartbeat_manager_interface.h"
 #include "src/spine/api/subscription_manager_interface.h"
@@ -83,6 +84,7 @@ struct DeviceLocalInterface {
   NodeManagementObject* (*get_node_management)(const DeviceLocalObject* self);
   BindingManagerObject* (*get_binding_manager)(const DeviceLocalObject* self);
   SubscriptionManagerObject* (*get_subscription_manager)(const DeviceLocalObject* self);
+  EventsManagerObject* (*get_events_manager)(const DeviceLocalObject* self);
   void (*notify_subscribers)(const DeviceLocalObject* self, const FeatureAddressType* feature_addr, const CmdType* cmd);
   NodeManagementDetailedDiscoveryDeviceInformationType* (*create_information)(const DeviceLocalObject* self);
   void (*lock)(DeviceLocalObject* self);
@@ -210,6 +212,11 @@ struct DeviceLocalObject {
  * @brief Device Local Get Subscription Manager caller definition
  */
 #define DEVICE_LOCAL_GET_SUBSCRIPTION_MANAGER(obj) (DEVICE_LOCAL_INTERFACE(obj)->get_subscription_manager(obj))
+
+/**
+ * @brief Device Local Get Events Manager caller definition
+ */
+#define DEVICE_LOCAL_GET_EVENTS_MANAGER(obj) (DEVICE_LOCAL_INTERFACE(obj)->get_events_manager(obj))
 
 /**
  * @brief Device Local Notify Subscribers caller definition

--- a/src/spine/api/device_remote_interface.h
+++ b/src/spine/api/device_remote_interface.h
@@ -41,6 +41,7 @@ extern "C" {
  * (Device Remote "virtual functions table" declaration)
  */
 typedef struct DeviceRemoteInterface DeviceRemoteInterface;
+typedef struct DeviceLocalObject DeviceLocalObject;
 
 /**
  * @brief Device Remote Object type definition
@@ -56,6 +57,7 @@ struct DeviceRemoteInterface {
   /** Extends DeviceInterface */
   DeviceInterface device_interface;
 
+  DeviceLocalObject* (*get_local_device)(const DeviceRemoteObject* self);
   const char* (*get_ski)(const DeviceRemoteObject* self);
   DataReaderObject* (*get_data_reader)(const DeviceRemoteObject* self);
   void (*add_entity)(DeviceRemoteObject* self, EntityRemoteObject* entity);
@@ -106,6 +108,11 @@ struct DeviceRemoteObject {
  * @brief Device Remote Interface class pointer typecast
  */
 #define DEVICE_REMOTE_INTERFACE(obj) (DEVICE_REMOTE_OBJECT(obj)->interface_)
+
+/**
+ * @brief Device Remote Get Local Device caller definition
+ */
+#define DEVICE_REMOTE_GET_LOCAL_DEVICE(obj) (DEVICE_REMOTE_INTERFACE(obj)->get_local_device(obj))
 
 /**
  * @brief Device Remote Get Ski caller definition

--- a/src/spine/api/events_manager_interface.h
+++ b/src/spine/api/events_manager_interface.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 NIBE AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @file
+ * @brief Events Manager interface declarations
+ */
+
+#ifndef SRC_SPINE_API_EVENTS_MANAGER_INTERFACE_H_
+#define SRC_SPINE_API_EVENTS_MANAGER_INTERFACE_H_
+
+#include "src/common/eebus_errors.h"
+#include "src/spine/api/events.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+typedef struct EventsManagerInterface EventsManagerInterface;
+typedef struct EventsManagerObject EventsManagerObject;
+
+struct EventsManagerInterface {
+  void (*destruct)(EventsManagerObject* self);
+  EebusError (*subscribe)(EventsManagerObject* self, EventHandlerLevel level, EventHandler handler, void* ctx);
+  EebusError (*unsubscribe)(EventsManagerObject* self, EventHandlerLevel level, EventHandler handler, void* ctx);
+  void (*publish)(EventsManagerObject* self, const EventPayload* payload);
+};
+
+struct EventsManagerObject {
+  const EventsManagerInterface* interface_;
+};
+
+#define EVENTS_MANAGER_OBJECT(obj) ((EventsManagerObject*)(obj))
+#define EVENTS_MANAGER_INTERFACE(obj) (EVENTS_MANAGER_OBJECT(obj)->interface_)
+
+#define EVENTS_DESTRUCT(obj) (EVENTS_MANAGER_INTERFACE(obj)->destruct(obj))
+#define EVENTS_SUBSCRIBE(obj, level, handler, ctx) (EVENTS_MANAGER_INTERFACE(obj)->subscribe(obj, level, handler, ctx))
+#define EVENTS_UNSUBSCRIBE(obj, level, handler, ctx) \
+  (EVENTS_MANAGER_INTERFACE(obj)->unsubscribe(obj, level, handler, ctx))
+#define EVENTS_PUBLISH(obj, payload) (EVENTS_MANAGER_INTERFACE(obj)->publish(obj, payload))
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif  // SRC_SPINE_API_EVENTS_MANAGER_INTERFACE_H_

--- a/src/spine/binding/binding_manager.c
+++ b/src/spine/binding/binding_manager.c
@@ -132,7 +132,7 @@ EebusError AddBinding(
       .function_type = kFunctionTypeBindingManagementRequestCall,
   };
 
-  EventPublish(&payload);
+  EVENTS_PUBLISH(DEVICE_LOCAL_GET_EVENTS_MANAGER(bm->local_device), &payload);
   return kEebusErrorOk;
 }
 
@@ -188,7 +188,7 @@ EebusError RemoveBinding(
       .function_type = kFunctionTypeBindingManagementDeleteCall,
   };
 
-  EventPublish(&payload);
+  EVENTS_PUBLISH(DEVICE_LOCAL_GET_EVENTS_MANAGER(bm->local_device), &payload);
   return kEebusErrorOk;
 }
 
@@ -229,7 +229,7 @@ void RemoveEntityBindings(BindingManagerObject* self, EntityRemoteObject* remote
           .local_feature = DEVICE_LOCAL_GET_FEATURE_WITH_ADDRESS(bm->local_device, server_addr),
       };
 
-      EventPublish(&payload);
+      EVENTS_PUBLISH(DEVICE_LOCAL_GET_EVENTS_MANAGER(bm->local_device), &payload);
       FeatureLinkContainerRemove(&bm->binding_entries, binding);
     } else {
       ++i;

--- a/src/spine/device/device_local.c
+++ b/src/spine/device/device_local.c
@@ -82,6 +82,7 @@ struct DeviceLocal {
   Device obj;
 
   Vector entities;
+  EventsManagerObject* events_manager;
   SubscriptionManagerObject* subscription_manager;
   BindingManagerObject* binding_manager;
   NodeManagementObject* node_management;
@@ -117,6 +118,7 @@ static EebusError HandleMessage(DeviceLocalObject* self, MessageBuffer* msg, Dev
 static NodeManagementObject* GetNodeManagement(const DeviceLocalObject* self);
 static BindingManagerObject* GetBindingManager(const DeviceLocalObject* self);
 static SubscriptionManagerObject* GetSubscriptionManager(const DeviceLocalObject* self);
+static EventsManagerObject* GetEventsManager(const DeviceLocalObject* self);
 static void
 NotifySubscribers(const DeviceLocalObject* self, const FeatureAddressType* feature_addr, const CmdType* cmd);
 static NodeManagementDetailedDiscoveryDeviceInformationType* CreateInformation(const DeviceLocalObject* self);
@@ -151,6 +153,7 @@ static const DeviceLocalInterface device_local_methods = {
     .get_node_management                    = GetNodeManagement,
     .get_binding_manager                    = GetBindingManager,
     .get_subscription_manager               = GetSubscriptionManager,
+    .get_events_manager                     = GetEventsManager,
     .notify_subscribers                     = NotifySubscribers,
     .create_information                     = CreateInformation,
     .lock                                   = Lock,
@@ -213,6 +216,7 @@ void DeviceLocalConstruct(
   DEVICE_LOCAL_INTERFACE(self) = &device_local_methods;
 
   VectorConstruct(&self->entities);
+  self->events_manager       = EventsManagerCreate();
   self->subscription_manager = SubscriptionManagerCreate(DEVICE_LOCAL_OBJECT(self));
   self->binding_manager      = BindingManagerCreate(DEVICE_LOCAL_OBJECT(self));
   self->node_management      = NULL;
@@ -230,7 +234,7 @@ void DeviceLocalConstruct(
 
   AddDeviceInformation(self, device_info);
 
-  EventSubscribe(kEventHandlerLevelCore, DeivceLocalHandleEvent, self);
+  EVENTS_SUBSCRIBE(self->events_manager, kEventHandlerLevelCore, DeivceLocalHandleEvent, self);
 }
 
 DeviceLocalObject*
@@ -262,7 +266,7 @@ void Destruct(DeviceObject* self) {
   EebusQueueDelete(dl->msg_queue);
   dl->msg_queue = NULL;
 
-  EventUnsubscribe(kEventHandlerLevelCore, DeivceLocalHandleEvent, dl);
+  EVENTS_UNSUBSCRIBE(dl->events_manager, kEventHandlerLevelCore, DeivceLocalHandleEvent, dl);
 
   StringLutRelease(&dl->remote_devices);
 
@@ -285,7 +289,14 @@ void Destruct(DeviceObject* self) {
 
   VectorDestruct(&dl->entities);
 
+  EventsManagerDelete(dl->events_manager);
+  dl->events_manager = NULL;
+
   DeviceDestruct(DEVICE_OBJECT(self));
+}
+
+EventsManagerObject* GetEventsManager(const DeviceLocalObject* self) {
+  return DEVICE_LOCAL(self)->events_manager;
 }
 
 void DeviceLocalTick(DeviceLocalObject* self) {
@@ -420,6 +431,7 @@ static void Stop(DeviceLocalObject* self) {
 
 void DeivceLocalHandleEvent(const EventPayload* payload, void* ctx) {
   DeviceLocal* const dl = (DeviceLocal*)(ctx);
+
   // Subscribe to NodeManagement after DetailedDiscovery is received
   if ((payload->event_type != kEventTypeDeviceChange) || (payload->change_type != kElementChangeAdd)) {
     return;
@@ -510,7 +522,7 @@ void RemoveRemoteDeviceConnection(DeviceLocalObject* self, const char* ski) {
       .device      = remote_device,
   };
 
-  EventPublish(&payload);
+  EVENTS_PUBLISH(dl->events_manager, &payload);
   EEBUS_MUTEX_UNLOCK(dl->mutex);
 }
 
@@ -532,7 +544,7 @@ void RemoveRemoteDevice(DeviceLocalObject* self, const char* ski) {
 
   // Only unsubscribe if we don't have any remote devices left
   if (StringLutGetSize(&dl->remote_devices) == 0) {
-    EventUnsubscribe(kEventHandlerLevelCore, DeivceLocalHandleEvent, dl);
+    EVENTS_UNSUBSCRIBE(dl->events_manager, kEventHandlerLevelCore, DeivceLocalHandleEvent, dl);
   }
 
   const DeviceAddressType remote_device_addr = {

--- a/src/spine/device/device_remote.c
+++ b/src/spine/device/device_remote.c
@@ -51,6 +51,7 @@ struct DeviceRemote {
 #define DEVICE_REMOTE(obj) ((DeviceRemote*)(obj))
 
 static void Destruct(DeviceObject* self);
+static DeviceLocalObject* GetLocalDevice(const DeviceRemoteObject* self);
 static const char* GetSki(const DeviceRemoteObject* self);
 static DataReaderObject* GetDataReader(const DeviceRemoteObject* self);
 static void AddEntity(DeviceRemoteObject* self, EntityRemoteObject* entity);
@@ -90,6 +91,7 @@ static const DeviceRemoteInterface device_remote_methods = {
         .create_destination_data = DeviceCreateDestinationData,
     },
 
+    .get_local_device               = GetLocalDevice,
     .get_ski                        = GetSki,
     .get_data_reader                = GetDataReader,
     .add_entity                     = AddEntity,
@@ -189,6 +191,13 @@ DeviceRemoteObject* DeviceRemoteCreate(DeviceLocalObject* local_device, const ch
   DeviceRemoteConstruct(device_remote, local_device, ski, sender);
 
   return DEVICE_REMOTE_OBJECT(device_remote);
+}
+
+DeviceLocalObject* GetLocalDevice(const DeviceRemoteObject* self) {
+  if (self == NULL) {
+    return NULL;
+  }
+  return DEVICE_REMOTE(self)->local_device;
 }
 
 void Destruct(DeviceObject* self) {

--- a/src/spine/events/events.c
+++ b/src/spine/events/events.c
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "src/spine/api/events.h"
+#include "src/spine/events/events.h"
 
 #include "src/common/eebus_malloc.h"
 #include "src/common/vector.h"
@@ -27,7 +27,27 @@ struct EventHandlerInfo {
   void* ctx;
 };
 
-static Vector handlers = {0};
+typedef struct EventsManager EventsManager;
+
+struct EventsManager {
+  EventsManagerObject obj;
+
+  Vector handlers;
+};
+
+#define EVENTS_MANAGER(obj) ((EventsManager*)(obj))
+
+static void Destruct(EventsManagerObject* self);
+static EebusError Subscribe(EventsManagerObject* self, EventHandlerLevel level, EventHandler handler, void* ctx);
+static EebusError Unsubscribe(EventsManagerObject* self, EventHandlerLevel level, EventHandler handler, void* ctx);
+static void Publish(EventsManagerObject* self, const EventPayload* payload);
+
+static const EventsManagerInterface events_manager_methods = {
+    .destruct    = Destruct,
+    .subscribe   = Subscribe,
+    .unsubscribe = Unsubscribe,
+    .publish     = Publish,
+};
 
 EventHandlerInfo* EventHandlerInfoCreate(EventHandlerLevel level, EventHandler handler, void* ctx) {
   EventHandlerInfo* info = EEBUS_MALLOC(sizeof(*info));
@@ -43,9 +63,10 @@ EventHandlerInfo* EventHandlerInfoCreate(EventHandlerLevel level, EventHandler h
 
 void EventHandlerInfoDelete(EventHandlerInfo* info) { EEBUS_FREE(info); }
 
-const EventHandlerInfo* EventHandlerFind(EventHandlerLevel level, EventHandler handler, void* ctx) {
-  for (size_t i = 0; i < VectorGetSize(&handlers); ++i) {
-    EventHandlerInfo* info = VectorGetElement(&handlers, i);
+const EventHandlerInfo*
+EventHandlerFind(const EventsManager* self, EventHandlerLevel level, EventHandler handler, void* ctx) {
+  for (size_t i = 0; i < VectorGetSize(&self->handlers); ++i) {
+    EventHandlerInfo* info = VectorGetElement(&self->handlers, i);
     if ((info->level == level) && (info->handler == handler) && (info->ctx == ctx)) {
       return info;
     }
@@ -54,8 +75,32 @@ const EventHandlerInfo* EventHandlerFind(EventHandlerLevel level, EventHandler h
   return NULL;
 }
 
-EebusError EventSubscribe(EventHandlerLevel level, EventHandler handler, void* ctx) {
-  if (EventHandlerFind(level, handler, ctx) != NULL) {
+void EventsManagerConstruct(EventsManager* self) {
+  EVENTS_MANAGER_INTERFACE(self) = &events_manager_methods;
+  VectorConstruct(&self->handlers);
+}
+
+EventsManagerObject* EventsManagerCreate(void) {
+  EventsManager* const events_manager = EEBUS_MALLOC(sizeof(*events_manager));
+  if (events_manager == NULL) {
+    return NULL;
+  }
+
+  EventsManagerConstruct(events_manager);
+  return EVENTS_MANAGER_OBJECT(events_manager);
+}
+
+void Destruct(EventsManagerObject* self) {
+  EventsManager* const events_manager = EVENTS_MANAGER(self);
+  for (size_t i = 0; i < VectorGetSize(&events_manager->handlers); ++i) {
+    EventHandlerInfoDelete(VectorGetElement(&events_manager->handlers, i));
+  }
+  VectorDestruct(&events_manager->handlers);
+}
+
+EebusError Subscribe(EventsManagerObject* self, EventHandlerLevel level, EventHandler handler, void* ctx) {
+  EventsManager* const events_manager = EVENTS_MANAGER(self);
+  if (EventHandlerFind(events_manager, level, handler, ctx) != NULL) {
     return kEebusErrorOk;
   }
 
@@ -64,30 +109,34 @@ EebusError EventSubscribe(EventHandlerLevel level, EventHandler handler, void* c
     return kEebusErrorMemoryAllocate;
   }
 
-  VectorPushBack(&handlers, new_handler_info);
+  VectorPushBack(&events_manager->handlers, new_handler_info);
   return kEebusErrorOk;
 }
 
-EebusError EventUnsubscribe(EventHandlerLevel level, EventHandler handler, void* ctx) {
-  const EventHandlerInfo* const info = EventHandlerFind(level, handler, ctx);
+EebusError Unsubscribe(EventsManagerObject* self, EventHandlerLevel level, EventHandler handler, void* ctx) {
+  EventsManager* const events_manager = EVENTS_MANAGER(self);
+  const EventHandlerInfo* const info  = EventHandlerFind(events_manager, level, handler, ctx);
   if (info == NULL) {
     return kEebusErrorNoChange;
   }
 
-  VectorRemove(&handlers, (void*)info);
+  VectorRemove(&events_manager->handlers, (void*)info);
   EventHandlerInfoDelete((void*)info);
-  if (VectorGetSize(&handlers) == 0) {
-    // Required to pass the memory check test as vector can keep the allocated buffer
-    VectorClear(&handlers);
+  if (VectorGetSize(&events_manager->handlers) == 0) {
+    VectorClear(&events_manager->handlers);
   }
 
   return kEebusErrorOk;
 }
 
-void EventPublish(const EventPayload* payload) {
-  // TODO: Check if level is required and should be analysed
-  for (size_t i = 0; i < VectorGetSize(&handlers); ++i) {
-    EventHandlerInfo* info = VectorGetElement(&handlers, i);
+void Publish(EventsManagerObject* self, const EventPayload* payload) {
+  if (payload == NULL) {
+    return;
+  }
+
+  EventsManager* const events_manager = EVENTS_MANAGER(self);
+  for (size_t i = 0; i < VectorGetSize(&events_manager->handlers); ++i) {
+    EventHandlerInfo* info = VectorGetElement(&events_manager->handlers, i);
     info->handler(payload, info->ctx);
   }
 }

--- a/src/spine/events/events.h
+++ b/src/spine/events/events.h
@@ -17,16 +17,21 @@
 #ifndef SRC_EEBUS_SRC_SPINE_EVENTS_EVENTS_H_
 #define SRC_EEBUS_SRC_SPINE_EVENTS_EVENTS_H_
 
-#include "src/common/eebus_errors.h"
-#include "src/spine/api/events.h"
+#include "src/common/eebus_malloc.h"
+#include "src/spine/api/events_manager_interface.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
 
-EebusError EventSubscribe(EventHandlerLevel level, EventHandler handler, void* ctx);
-EebusError EventUnsubscribe(EventHandlerLevel level, EventHandler handler, void* ctx);
-void EventPublish(const EventPayload* payload);
+EventsManagerObject* EventsManagerCreate(void);
+
+static inline void EventsManagerDelete(EventsManagerObject* events_manager) {
+  if (events_manager != NULL) {
+    EVENTS_DESTRUCT(events_manager);
+    EEBUS_FREE(events_manager);
+  }
+}
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/spine/feature/feature_local.c
+++ b/src/spine/feature/feature_local.c
@@ -751,7 +751,7 @@ void PublishDataUpdateEvent(
       .cmd_classifier = &cmd_classifier,
   };
 
-  EventPublish(&payload);
+  EVENTS_PUBLISH(DEVICE_LOCAL_GET_EVENTS_MANAGER(FEATURE_LOCAL_GET_DEVICE(FEATURE_LOCAL_OBJECT(self))), &payload);
 }
 
 EebusError ProcessNotify(FeatureLocal* self, const Message* msg) {

--- a/src/spine/node_management/node_management_detailed_discovery.c
+++ b/src/spine/node_management/node_management_detailed_discovery.c
@@ -187,8 +187,9 @@ EebusError ProcessReadDetailedDiscoveryData(NodeManagement* self, const Message*
 }
 
 EebusError ProcessReplyDetailedDiscoveryData(NodeManagement* self, const Message* msg) {
-  UNUSED(self);
   DeviceRemoteObject* const dr = msg->device_remote;
+  EventsManagerObject* const events_manager
+      = DEVICE_LOCAL_GET_EVENTS_MANAGER(FEATURE_LOCAL_GET_DEVICE(FEATURE_LOCAL_OBJECT(self)));
 
   const NodeManagementDetailedDiscoveryDataType* const discovery_data
       = (const NodeManagementDetailedDiscoveryDataType*)msg->cmd->data_choice;
@@ -231,7 +232,7 @@ EebusError ProcessReplyDetailedDiscoveryData(NodeManagement* self, const Message
       .function_type = kFunctionTypeNodeManagementDetailedDiscoveryData,
   };
 
-  EventPublish(&payload);
+  EVENTS_PUBLISH(events_manager, &payload);
 
   // Publish event for each added remote entity
   for (size_t i = 0; i < VectorGetSize(entities); ++i) {
@@ -247,7 +248,7 @@ EebusError ProcessReplyDetailedDiscoveryData(NodeManagement* self, const Message
         .function_type = kFunctionTypeNodeManagementDetailedDiscoveryData,
     };
 
-    EventPublish(&payload);
+    EVENTS_PUBLISH(events_manager, &payload);
   }
 
   FeatureAddressDelete(feature_remote_addr);

--- a/src/spine/node_management/node_management_remote.c
+++ b/src/spine/node_management/node_management_remote.c
@@ -20,6 +20,8 @@
 
 #include "src/spine/node_management/node_management_remote.h"
 #include "src/common/vector.h"
+#include "src/spine/api/device_local_interface.h"
+#include "src/spine/api/device_remote_interface.h"
 #include "src/spine/events/events.h"
 #include "src/spine/feature/feature_remote_internal.h"
 #include "src/spine/model/model.h"
@@ -127,6 +129,7 @@ void PublishUseCaseSupportedEvent(
   if (dr == NULL) {
     return;
   }
+  EventsManagerObject* const events_manager = DEVICE_LOCAL_GET_EVENTS_MANAGER(DEVICE_REMOTE_GET_LOCAL_DEVICE(dr));
 
   const UseCaseFilterType use_case_filter = {
       .actor            = actor,
@@ -155,11 +158,11 @@ void PublishUseCaseSupportedEvent(
 
     for (size_t i = 0; i < VectorGetSize(entities); i++) {
       payload.entity = (EntityRemoteObject*)VectorGetElement(entities, i);
-      EventPublish(&payload);
+      EVENTS_PUBLISH(events_manager, &payload);
     }
   } else {
     payload.entity = DEVICE_REMOTE_GET_ENTITY(DEVICE_REMOTE_OBJECT(dr), addr->entity, addr->entity_size);
-    EventPublish(&payload);
+    EVENTS_PUBLISH(events_manager, &payload);
   }
 }
 
@@ -245,7 +248,7 @@ EebusError UpdateData(
       .function_type = kFunctionTypeNodeManagementUseCaseData,
   };
 
-  EventPublish(&payload);
+  EVENTS_PUBLISH(DEVICE_LOCAL_GET_EVENTS_MANAGER(DEVICE_REMOTE_GET_LOCAL_DEVICE(dr)), &payload);
 
   const UseCaseInformationListDataType* const use_case_data_new = (const UseCaseInformationListDataType*)
       FeatureRemoteGetData(FEATURE_REMOTE_OBJECT(self), kFunctionTypeNodeManagementUseCaseData);

--- a/src/spine/node_management/node_management_usecase.c
+++ b/src/spine/node_management/node_management_usecase.c
@@ -20,6 +20,7 @@
 
 #include "src/common/array_util.h"
 #include "src/common/eebus_arguments.h"
+#include "src/spine/api/device_local_interface.h"
 #include "src/spine/api/message.h"
 #include "src/spine/events/events.h"
 #include "src/spine/model/cmd.h"
@@ -71,8 +72,6 @@ EebusError ProcessReadUseCaseData(NodeManagement* self, const Message* msg) {
 }
 
 EebusError ProcessReplyUseCaseData(NodeManagement* self, const Message* msg) {
-  UNUSED(self);
-
   const NodeManagementUseCaseDataType* const usecase_data = (const NodeManagementUseCaseDataType*)msg->cmd->data_choice;
 
   FeatureRemoteObject* const fr = msg->feature_remote;
@@ -98,7 +97,7 @@ EebusError ProcessReplyUseCaseData(NodeManagement* self, const Message* msg) {
       .cmd_classifier = &msg->cmd_classifier,
   };
 
-  EventPublish(&payload);
+  EVENTS_PUBLISH(DEVICE_LOCAL_GET_EVENTS_MANAGER(FEATURE_LOCAL_GET_DEVICE(FEATURE_LOCAL_OBJECT(self))), &payload);
   return kEebusErrorOk;
 }
 

--- a/src/spine/subscription/subscription_manager.c
+++ b/src/spine/subscription/subscription_manager.c
@@ -139,7 +139,7 @@ EebusError AddSubscription(
       .function_type = kFunctionTypeSubscriptionManagementRequestCall,
   };
 
-  EventPublish(&payload);
+  EVENTS_PUBLISH(DEVICE_LOCAL_GET_EVENTS_MANAGER(sm->local_device), &payload);
   return kEebusErrorOk;
 }
 
@@ -195,7 +195,7 @@ EebusError RemoveSubscription(
       .function_type = kFunctionTypeSubscriptionManagementDeleteCall,
   };
 
-  EventPublish(&payload);
+  EVENTS_PUBLISH(DEVICE_LOCAL_GET_EVENTS_MANAGER(sm->local_device), &payload);
   return kEebusErrorOk;
 }
 
@@ -236,7 +236,7 @@ void RemoveEntitySubscriptions(SubscriptionManagerObject* self, EntityRemoteObje
           .local_feature = DEVICE_LOCAL_GET_FEATURE_WITH_ADDRESS(sm->local_device, server_addr),
       };
 
-      EventPublish(&payload);
+      EVENTS_PUBLISH(DEVICE_LOCAL_GET_EVENTS_MANAGER(sm->local_device), &payload);
       FeatureLinkContainerRemove(&sm->subscription_entries, subscription);
     } else {
       ++i;

--- a/src/use_case/use_case.c
+++ b/src/use_case/use_case.c
@@ -21,6 +21,7 @@
 #include "src/use_case/use_case.h"
 
 #include "src/common/eebus_malloc.h"
+#include "src/spine/api/device_local_interface.h"
 #include "src/spine/api/entity_local_interface.h"
 #include "src/spine/events/events.h"
 #include "src/spine/model/usecase_information_types.h"
@@ -58,7 +59,12 @@ void UseCaseConstruct(
   UseCaseEntityAddUseCaseInfo(self);
   self->event_handler = event_handler;
   if (self->event_handler != NULL) {
-    EventSubscribe(kEventHandlerLevelApplication, event_handler, self);
+    EVENTS_SUBSCRIBE(
+        DEVICE_LOCAL_GET_EVENTS_MANAGER(self->local_device),
+        kEventHandlerLevelApplication,
+        self->event_handler,
+        self
+    );
   }
 }
 
@@ -66,7 +72,12 @@ void UseCaseDestruct(UseCaseObject* self) {
   UseCase* use_case = USE_CASE(self);
 
   if (use_case->event_handler != NULL) {
-    EventUnsubscribe(kEventHandlerLevelApplication, use_case->event_handler, self);
+    EVENTS_UNSUBSCRIBE(
+        DEVICE_LOCAL_GET_EVENTS_MANAGER(use_case->local_device),
+        kEventHandlerLevelApplication,
+        use_case->event_handler,
+        self
+    );
   }
 }
 

--- a/tests/src/CMakeLists.txt
+++ b/tests/src/CMakeLists.txt
@@ -45,6 +45,9 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/spine/model/function_data
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/spine/feature
     ${EXECUTABLE_OUTPUT_PATH}/spine/feature)
 
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/spine/events
+    ${EXECUTABLE_OUTPUT_PATH}/spine/events)
+
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/spine/function
     ${EXECUTABLE_OUTPUT_PATH}/spine/function)
 

--- a/tests/src/mocks/spine/device/device_local_mock.cpp
+++ b/tests/src/mocks/spine/device/device_local_mock.cpp
@@ -49,6 +49,7 @@ static EebusError HandleMessage(DeviceLocalObject* self, MessageBuffer* msg, Dev
 static NodeManagementObject* GetNodeManagement(const DeviceLocalObject* self);
 static BindingManagerObject* GetBindingManager(const DeviceLocalObject* self);
 static SubscriptionManagerObject* GetSubscriptionManager(const DeviceLocalObject* self);
+static EventsManagerObject* GetEventsManager(const DeviceLocalObject* self);
 static void
 NotifySubscribers(const DeviceLocalObject* self, const FeatureAddressType* feature_addr, const CmdType* cmd);
 static NodeManagementDetailedDiscoveryDeviceInformationType* CreateInformation(const DeviceLocalObject* self);
@@ -83,6 +84,7 @@ static const DeviceLocalInterface device_local_methods = {
     .get_node_management                    = GetNodeManagement,
     .get_binding_manager                    = GetBindingManager,
     .get_subscription_manager               = GetSubscriptionManager,
+    .get_events_manager                     = GetEventsManager,
     .notify_subscribers                     = NotifySubscribers,
     .create_information                     = CreateInformation,
     .lock                                   = Lock,
@@ -236,6 +238,11 @@ BindingManagerObject* GetBindingManager(const DeviceLocalObject* self) {
 SubscriptionManagerObject* GetSubscriptionManager(const DeviceLocalObject* self) {
   DeviceLocalMock* const mock = DEVICE_LOCAL_MOCK(self);
   return mock->gmock->GetSubscriptionManager(self);
+}
+
+EventsManagerObject* GetEventsManager(const DeviceLocalObject* self) {
+  DeviceLocalMock* const mock = DEVICE_LOCAL_MOCK(self);
+  return mock->gmock->GetEventsManager(self);
 }
 
 void NotifySubscribers(const DeviceLocalObject* self, const FeatureAddressType* feature_addr, const CmdType* cmd) {

--- a/tests/src/mocks/spine/device/device_local_mock.h
+++ b/tests/src/mocks/spine/device/device_local_mock.h
@@ -58,6 +58,7 @@ class DeviceLocalGMockInterface : public DeviceGMockInterface {
   virtual NodeManagementObject* GetNodeManagement(const DeviceLocalObject* self)                                   = 0;
   virtual BindingManagerObject* GetBindingManager(const DeviceLocalObject* self)                                   = 0;
   virtual SubscriptionManagerObject* GetSubscriptionManager(const DeviceLocalObject* self)                         = 0;
+  virtual EventsManagerObject* GetEventsManager(const DeviceLocalObject* self)                                     = 0;
   virtual void
   NotifySubscribers(const DeviceLocalObject* self, const FeatureAddressType* feature_addr, const CmdType* cmd)
       = 0;
@@ -93,6 +94,7 @@ class DeviceLocalGMock : public DeviceLocalGMockInterface {
   MOCK_METHOD1(GetNodeManagement, NodeManagementObject*(const DeviceLocalObject*));
   MOCK_METHOD1(GetBindingManager, BindingManagerObject*(const DeviceLocalObject*));
   MOCK_METHOD1(GetSubscriptionManager, SubscriptionManagerObject*(const DeviceLocalObject*));
+  MOCK_METHOD1(GetEventsManager, EventsManagerObject*(const DeviceLocalObject*));
   MOCK_METHOD3(NotifySubscribers, void(const DeviceLocalObject*, const FeatureAddressType*, const CmdType*));
   MOCK_METHOD1(CreateInformation, NodeManagementDetailedDiscoveryDeviceInformationType*(const DeviceLocalObject*));
   MOCK_METHOD1(Lock, void(DeviceLocalObject*));

--- a/tests/src/mocks/spine/device/device_remote_mock.cpp
+++ b/tests/src/mocks/spine/device/device_remote_mock.cpp
@@ -29,6 +29,7 @@ static const char* GetAddress(const DeviceObject* self);
 static const DeviceTypeType* GetDeviceType(const DeviceObject* self);
 static const NetworkManagementFeatureSetType* GetFeatureSet(const DeviceObject* self);
 static const NodeManagementDestinationDataType* CreateDestinationData(const DeviceObject* self);
+static DeviceLocalObject* GetLocalDevice(const DeviceRemoteObject* self);
 static const char* GetSki(const DeviceRemoteObject* self);
 static DataReaderObject* GetDataReader(const DeviceRemoteObject* self);
 static void AddEntity(DeviceRemoteObject* self, EntityRemoteObject* entity);
@@ -68,6 +69,7 @@ static const DeviceRemoteInterface device_remote_methods = {
         .create_destination_data = CreateDestinationData,
     },
 
+    .get_local_device               = GetLocalDevice,
     .get_ski                        = GetSki,
     .get_data_reader                = GetDataReader,
     .add_entity                     = AddEntity,
@@ -137,6 +139,11 @@ const NetworkManagementFeatureSetType* GetFeatureSet(const DeviceObject* self) {
 const NodeManagementDestinationDataType* CreateDestinationData(const DeviceObject* self) {
   DeviceRemoteMock* const mock = DEVICE_REMOTE_MOCK(self);
   return mock->gmock->CreateDestinationData(self);
+}
+
+DeviceLocalObject* GetLocalDevice(const DeviceRemoteObject* self) {
+  DeviceRemoteMock* const mock = DEVICE_REMOTE_MOCK(self);
+  return mock->gmock->GetLocalDevice(self);
 }
 
 const char* GetSki(const DeviceRemoteObject* self) {

--- a/tests/src/mocks/spine/device/device_remote_mock.h
+++ b/tests/src/mocks/spine/device/device_remote_mock.h
@@ -31,6 +31,7 @@
 class DeviceRemoteGMockInterface : public DeviceGMockInterface {
  public:
   virtual ~DeviceRemoteGMockInterface() {};
+  virtual DeviceLocalObject* GetLocalDevice(const DeviceRemoteObject* self)    = 0;
   virtual const char* GetSki(const DeviceRemoteObject* self)                   = 0;
   virtual DataReaderObject* GetDataReader(const DeviceRemoteObject* self)      = 0;
   virtual void AddEntity(DeviceRemoteObject* self, EntityRemoteObject* entity) = 0;
@@ -76,6 +77,7 @@ class DeviceRemoteGMock : public DeviceRemoteGMockInterface {
   MOCK_METHOD1(GetDeviceType, const DeviceTypeType*(const DeviceObject*));
   MOCK_METHOD1(GetFeatureSet, const NetworkManagementFeatureSetType*(const DeviceObject*));
   MOCK_METHOD1(CreateDestinationData, const NodeManagementDestinationDataType*(const DeviceObject*));
+  MOCK_METHOD1(GetLocalDevice, DeviceLocalObject*(const DeviceRemoteObject*));
   MOCK_METHOD1(GetSki, const char*(const DeviceRemoteObject*));
   MOCK_METHOD1(GetDataReader, DataReaderObject*(const DeviceRemoteObject*));
   MOCK_METHOD2(AddEntity, void(DeviceRemoteObject*, EntityRemoteObject*));

--- a/tests/src/mocks/spine/events/event_handler_mock.cpp
+++ b/tests/src/mocks/spine/events/event_handler_mock.cpp
@@ -32,10 +32,11 @@ void TestEventHandler(const EventPayload* payload, void* ctx) {
   }
 }
 
-EventHandlerMockInst::EventHandlerMockInst() : MockInst(event_handler_mock) {
-  EventSubscribe(kEventHandlerLevelApplication, TestEventHandler, nullptr);
+EventHandlerMockInst::EventHandlerMockInst(EventsManagerObject* events_manager)
+    : MockInst(event_handler_mock), events_manager_(events_manager) {
+  EVENTS_SUBSCRIBE(events_manager_, kEventHandlerLevelApplication, TestEventHandler, nullptr);
 }
 
 EventHandlerMockInst::~EventHandlerMockInst() {
-  EventUnsubscribe(kEventHandlerLevelApplication, TestEventHandler, nullptr);
+  EVENTS_UNSUBSCRIBE(events_manager_, kEventHandlerLevelApplication, TestEventHandler, nullptr);
 }

--- a/tests/src/mocks/spine/events/event_handler_mock.h
+++ b/tests/src/mocks/spine/events/event_handler_mock.h
@@ -21,6 +21,7 @@
 #ifndef TESTS_SRC_MOCKS_SPINE_EVENTS_EVENT_HANDLER_MOCK_H_
 #define TESTS_SRC_MOCKS_SPINE_EVENTS_EVENT_HANDLER_MOCK_H_
 
+#include "src/spine/api/events_manager_interface.h"
 #include "tests/src/mocks/mock_inst.h"
 
 class EventHandlerInterface {
@@ -38,8 +39,11 @@ class EventHandlerMock : public EventHandlerInterface {
 
 class EventHandlerMockInst : public MockInst<EventHandlerMock> {
  public:
-  EventHandlerMockInst();
+  explicit EventHandlerMockInst(EventsManagerObject* events_manager);
   ~EventHandlerMockInst();
+
+ private:
+  EventsManagerObject* events_manager_;
 };
 
 #endif  // TESTS_SRC_MOCKS_SPINE_EVENTS_EVENT_HANDLER_MOCK_H_

--- a/tests/src/spine/events/CMakeLists.txt
+++ b/tests/src/spine/events/CMakeLists.txt
@@ -1,0 +1,61 @@
+cmake_minimum_required(VERSION 3.15)
+
+set(TEST_NAME events_test)
+
+project(${TESTS_NAME} LANGUAGES C CXX)
+
+add_executable(${TEST_NAME})
+
+if(WIN32)
+  set_property(TARGET ${TEST_NAME} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+endif()
+
+target_sources(
+  ${TEST_NAME}
+  PRIVATE
+  ${GTEST_SOURCES}
+
+  ${MAIN_PROJ_SOURCES_PATH}/common/vector.c
+  ${MAIN_PROJ_SOURCES_PATH}/spine/events/events.c
+
+  events_test.cpp
+)
+
+target_include_directories(
+  ${TEST_NAME}
+  PRIVATE
+  ${PROJECT_INCLUDES_PATH}
+)
+
+target_compile_options(
+  ${TEST_NAME}
+  PRIVATE
+  ${PROJECT_COMPILE_OPTIONS}
+)
+
+target_compile_definitions(
+  ${TEST_NAME}
+  PRIVATE
+  ${PROJECT_COMPILE_DEFINITIONS}
+)
+
+target_link_options(
+  ${TEST_NAME}
+  PRIVATE
+  ${PROJECT_LINK_OPTIONS}
+)
+
+target_link_libraries(
+  ${TEST_NAME}
+  PRIVATE
+  ${PROJECT_LINK_LIBRARIES}
+)
+
+add_test(
+  NAME
+  ${TEST_NAME}
+  COMMAND
+  ${EXECUTABLE_OUTPUT_PATH}/${TEST_NAME}
+)
+
+gtest_discover_tests(${TEST_NAME})

--- a/tests/src/spine/events/events_test.cpp
+++ b/tests/src/spine/events/events_test.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 NIBE AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "src/spine/events/events.h"
+
+struct EventHandlerContext {
+  size_t call_count;
+  const EventPayload* payload;
+};
+
+static void CountEvent(const EventPayload* payload, void* ctx) {
+  EventHandlerContext* const handler_ctx = static_cast<EventHandlerContext*>(ctx);
+  ++handler_ctx->call_count;
+  handler_ctx->payload = payload;
+}
+
+TEST(EventsManagerTests, PublishOnlyNotifiesOwnSubscribers) {
+  std::unique_ptr<EventsManagerObject, decltype(&EventsManagerDelete)> first{
+      EventsManagerCreate(),
+      EventsManagerDelete
+  };
+  std::unique_ptr<EventsManagerObject, decltype(&EventsManagerDelete)> second{
+      EventsManagerCreate(),
+      EventsManagerDelete
+  };
+
+  ASSERT_NE(first, nullptr);
+  ASSERT_NE(second, nullptr);
+
+  EventHandlerContext first_ctx{};
+  EventHandlerContext second_ctx{};
+  ASSERT_EQ(EVENTS_SUBSCRIBE(first.get(), kEventHandlerLevelApplication, CountEvent, &first_ctx), kEebusErrorOk);
+  ASSERT_EQ(EVENTS_SUBSCRIBE(second.get(), kEventHandlerLevelApplication, CountEvent, &second_ctx), kEebusErrorOk);
+
+  const EventPayload first_payload = {
+      .ski         = "first",
+      .event_type  = kEventTypeDeviceChange,
+      .change_type = kElementChangeAdd,
+  };
+  EVENTS_PUBLISH(first.get(), &first_payload);
+
+  EXPECT_EQ(first_ctx.call_count, 1);
+  EXPECT_EQ(first_ctx.payload, &first_payload);
+  EXPECT_EQ(second_ctx.call_count, 0);
+  EXPECT_EQ(second_ctx.payload, nullptr);
+
+  const EventPayload second_payload = {
+      .ski         = "second",
+      .event_type  = kEventTypeDeviceChange,
+      .change_type = kElementChangeAdd,
+  };
+  EVENTS_PUBLISH(second.get(), &second_payload);
+
+  EXPECT_EQ(first_ctx.call_count, 1);
+  EXPECT_EQ(second_ctx.call_count, 1);
+  EXPECT_EQ(second_ctx.payload, &second_payload);
+}

--- a/tests/src/spine/feature/write_approve_test_suite.cpp
+++ b/tests/src/spine/feature/write_approve_test_suite.cpp
@@ -23,6 +23,7 @@
 constexpr uint8_t kMaxResponseTimeSec = TIME_MS_TO_S(kDefaultMaxResponseDelayMs);
 
 void WriteApproveTestSuite::SetUp() {
+  events_manager_.reset(EventsManagerCreate());
   device_local_mock_.reset(DeviceLocalMockCreate());
   entity_local_mock_.reset(EntityLocalMockCreate());
   device_remote_mock_.reset(DeviceRemoteMockCreate());
@@ -47,6 +48,9 @@ void WriteApproveTestSuite::SetUp() {
 
   EXPECT_CALL(*entity_local_mock_->gmock, GetDevice(ENTITY_LOCAL_OBJECT(entity_local_mock_.get())))
       .WillRepeatedly(::testing::Return(DEVICE_LOCAL_OBJECT(device_local_mock_.get())));
+
+  EXPECT_CALL(*device_local_mock_->gmock, GetEventsManager(DEVICE_LOCAL_OBJECT(device_local_mock_.get())))
+      .WillRepeatedly(::testing::Return(events_manager_.get()));
 
   EXPECT_CALL(*device_local_mock_->gmock, NotifySubscribers(::testing::_, ::testing::_, ::testing::_))
       .WillRepeatedly(::testing::Return());
@@ -79,6 +83,7 @@ void WriteApproveTestSuite::TearDown() {
   sender_mock_.reset();
 
   feature_local_object_.reset();
+  events_manager_.reset();
   entity_address_.reset();
   spine_data_.reset();
   cmd_mock_.reset();

--- a/tests/src/spine/feature/write_approve_test_suite.h
+++ b/tests/src/spine/feature/write_approve_test_suite.h
@@ -32,6 +32,7 @@
 #include "src/spine/api/feature_local_interface.h"
 #include "src/spine/api/message.h"
 #include "src/spine/api/pending_write_request_interface.h"
+#include "src/spine/events/events.h"
 #include "src/spine/feature/feature_local.h"
 #include "src/spine/model/model.h"
 
@@ -44,6 +45,7 @@ class WriteApproveTestSuite : public testing::Test {
   Message CreateTestMessage(FunctionType data_type_id, uint64_t msg_counter);
 
  protected:
+  std::unique_ptr<EventsManagerObject, decltype(&EventsManagerDelete)> events_manager_{nullptr, EventsManagerDelete};
   std::unique_ptr<DeviceLocalMock, decltype(&DeviceLocalMockDelete)> device_local_mock_{nullptr, DeviceLocalMockDelete};
   std::unique_ptr<EntityLocalMock, decltype(&EntityLocalMockDelete)> entity_local_mock_{nullptr, EntityLocalMockDelete};
 

--- a/tests/src/spine/node_management/node_management_remote/CMakeLists.txt
+++ b/tests/src/spine/node_management/node_management_remote/CMakeLists.txt
@@ -41,6 +41,7 @@ target_sources(
   ${MAIN_PROJ_SOURCES_PATH}/spine/node_management/node_management_remote.c
 
   # Mocks sources
+  ${MOCKS_SOURCES_PATH}/spine/device/device_local_mock.cpp
   ${MOCKS_SOURCES_PATH}/spine/device/device_remote_mock.cpp
   ${MOCKS_SOURCES_PATH}/spine/entity/entity_remote_mock.cpp
   ${MOCKS_SOURCES_PATH}/spine/events/event_handler_mock.cpp

--- a/tests/src/spine/node_management/node_management_remote/node_management_remote_test.cpp
+++ b/tests/src/spine/node_management/node_management_remote/node_management_remote_test.cpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 
+#include "mocks/spine/device/device_local_mock.h"
 #include "mocks/spine/device/device_remote_mock.h"
 #include "mocks/spine/entity/entity_remote_mock.h"
 #include "src/common/array_util.h"
@@ -102,6 +103,10 @@ class NodeManagementRemoteUpdateDataTests : public ::testing::TestWithParam<Node
       DeviceRemoteMockDelete
   };
 
+  std::unique_ptr<DeviceLocalMock, decltype(&DeviceLocalMockDelete)> device_local_mock_{nullptr, DeviceLocalMockDelete};
+
+  std::unique_ptr<EventsManagerObject, decltype(&EventsManagerDelete)> events_manager_{nullptr, EventsManagerDelete};
+
   std::unique_ptr<EntityRemoteMock, decltype(&EntityRemoteMockDelete)> entity_remote_mock_{
       nullptr,
       EntityRemoteMockDelete
@@ -113,7 +118,13 @@ class NodeManagementRemoteUpdateDataTests : public ::testing::TestWithParam<Node
   };
 
   void SetUp() override {
+    events_manager_.reset(EventsManagerCreate());
+    device_local_mock_.reset(DeviceLocalMockCreate());
+    EXPECT_CALL(*device_local_mock_->gmock, GetEventsManager(_)).WillRepeatedly(Return(events_manager_.get()));
+
     device_remote_mock_.reset(DeviceRemoteMockCreate());
+    EXPECT_CALL(*device_remote_mock_->gmock, GetLocalDevice(_))
+        .WillRepeatedly(Return(DEVICE_LOCAL_OBJECT(device_local_mock_.get())));
 
     EXPECT_CALL(*device_remote_mock_->gmock, GetSki(_))
         .WillRepeatedly(Return("0123456789abcdefedcb0123456789abcdefedcb"));
@@ -132,10 +143,13 @@ class NodeManagementRemoteUpdateDataTests : public ::testing::TestWithParam<Node
   void TearDown() override {
     EXPECT_CALL(*entity_remote_mock_->gmock, Destruct(ENTITY_OBJECT(entity_remote_mock_.get())));
     EXPECT_CALL(*device_remote_mock_->gmock, Destruct(DEVICE_OBJECT(device_remote_mock_.get())));
+    EXPECT_CALL(*device_local_mock_->gmock, Destruct(DEVICE_OBJECT(device_local_mock_.get())));
 
     node_management_remote_.reset();
     entity_remote_mock_.reset();
     device_remote_mock_.reset();
+    device_local_mock_.reset();
+    events_manager_.reset();
 
     CheckForMemoryLeaks();
   }
@@ -159,7 +173,7 @@ class NodeManagementRemoteUpdateDataTests : public ::testing::TestWithParam<Node
 TEST_P(NodeManagementRemoteUpdateDataTests, NodeManagementRemoteUpdateDataTests) {
   ASSERT_EQ(SetUseCaseData(GetParam().data_txt), kEebusErrorOk) << "Wrong Use Case Data input!";
 
-  EventHandlerMockInst event_handler_mock_inst;
+  EventHandlerMockInst event_handler_mock_inst(events_manager_.get());
 
   EXPECT_CALL(*event_handler_mock_inst, Handle(IsDeviceUpdatePayload(), _));
 
@@ -292,6 +306,10 @@ class NodeManagementRemoteNullEntityAddrTests : public ::testing::TestWithParam<
       DeviceRemoteMockDelete
   };
 
+  std::unique_ptr<DeviceLocalMock, decltype(&DeviceLocalMockDelete)> device_local_mock_{nullptr, DeviceLocalMockDelete};
+
+  std::unique_ptr<EventsManagerObject, decltype(&EventsManagerDelete)> events_manager_{nullptr, EventsManagerDelete};
+
   std::unique_ptr<EntityRemoteMock, decltype(&EntityRemoteMockDelete)> nm_entity_remote_mock_{
       nullptr,
       EntityRemoteMockDelete
@@ -315,7 +333,13 @@ class NodeManagementRemoteNullEntityAddrTests : public ::testing::TestWithParam<
   Vector entities_vector_{};
 
   void SetUp() override {
+    events_manager_.reset(EventsManagerCreate());
+    device_local_mock_.reset(DeviceLocalMockCreate());
+    EXPECT_CALL(*device_local_mock_->gmock, GetEventsManager(_)).WillRepeatedly(Return(events_manager_.get()));
+
     device_remote_mock_.reset(DeviceRemoteMockCreate());
+    EXPECT_CALL(*device_remote_mock_->gmock, GetLocalDevice(_))
+        .WillRepeatedly(Return(DEVICE_LOCAL_OBJECT(device_local_mock_.get())));
     EXPECT_CALL(*device_remote_mock_->gmock, GetSki(_))
         .WillRepeatedly(Return("0123456789abcdefedcb0123456789abcdefedcb"));
 
@@ -341,6 +365,7 @@ class NodeManagementRemoteNullEntityAddrTests : public ::testing::TestWithParam<
     EXPECT_CALL(*entity_remote_mock_1_->gmock, Destruct(ENTITY_OBJECT(entity_remote_mock_1_.get())));
     EXPECT_CALL(*entity_remote_mock_2_->gmock, Destruct(ENTITY_OBJECT(entity_remote_mock_2_.get())));
     EXPECT_CALL(*device_remote_mock_->gmock, Destruct(DEVICE_OBJECT(device_remote_mock_.get())));
+    EXPECT_CALL(*device_local_mock_->gmock, Destruct(DEVICE_OBJECT(device_local_mock_.get())));
 
     node_management_remote_.reset();
     VectorDestruct(&entities_vector_);
@@ -348,6 +373,8 @@ class NodeManagementRemoteNullEntityAddrTests : public ::testing::TestWithParam<
     entity_remote_mock_1_.reset();
     entity_remote_mock_2_.reset();
     device_remote_mock_.reset();
+    device_local_mock_.reset();
+    events_manager_.reset();
 
     CheckForMemoryLeaks();
   }
@@ -371,7 +398,7 @@ class NodeManagementRemoteNullEntityAddrTests : public ::testing::TestWithParam<
 TEST_P(NodeManagementRemoteNullEntityAddrTests, NullEntityAddrPublishesForEachEntity) {
   ASSERT_EQ(SetUseCaseData(GetParam().data_txt), kEebusErrorOk) << "Wrong Use Case Data input!";
 
-  EventHandlerMockInst event_handler_mock_inst;
+  EventHandlerMockInst event_handler_mock_inst(events_manager_.get());
 
   EXPECT_CALL(*event_handler_mock_inst, Handle(IsDeviceUpdatePayload(), _));
 

--- a/tests/src/use_case/use_case_test_fixture.cpp
+++ b/tests/src/use_case/use_case_test_fixture.cpp
@@ -65,12 +65,13 @@ void UseCaseTestFixture::SetUp() {
 }
 
 void UseCaseTestFixture::TearDown() {
+  DEVICE_LOCAL_REMOVE_REMOTE_DEVICE(device_local_.get(), kRemoteSki);
+  TearDownUseCase();
+
   device_local_.reset();
 
   EXPECT_CALL(*data_write_mock_->gmock, Destruct(_)).WillOnce(Return());
   data_write_mock_.reset();
-
-  TearDownUseCase();
 
   device_info_.reset();
 


### PR DESCRIPTION
## Problem

The event bus was process-global, so every subscriber received events from every EEBus service instance in the process. In a multi-instance HEMS this allowed use cases and `DeviceLocal` handlers to process another instance's devices, causing duplicate subscriptions, cross-instance disconnect handling, and writes to the wrong remote device.

## Change

Follow the per-device event architecture proposed in review:

- turn the existing event mechanism into a dynamically allocated `EventsManager` class,
- own one `EventsManager` from each `DeviceLocal` and expose it through `DEVICE_LOCAL_GET_EVENTS_MANAGER()`,
- route every publisher through the manager of its owning local device,
- subscribe each use case directly to its local device's manager,
- expose the remote-to-local device back-reference through `DeviceRemoteInterface`, and
- remove the payload owner tag, process-global handler storage, and post-publication ownership filtering.

The test fixtures now model the same ownership order: remote disconnect events are delivered while the manager and use cases are alive, use cases unsubscribe, and the local device is destroyed last.

## Verification

- clang-format 18: clean
- MSVC: OpenEEBus library plus `hems` and `heat_pump` examples build successfully
- GCC 14.4 / Debian Trixie: 674/674 tests pass
- focused instance-isolation test verifies that publishing on one manager never reaches another manager's subscriber