### PR TITLE
Announce scenario 3 (heartbeat) in the EG LPC/LPP use cases

### DIFF
--- a/src/use_case/actor/eg/lpc/eg_lpc.c
+++ b/src/use_case/actor/eg/lpc/eg_lpc.c
@@ -38,9 +38,7 @@ static const EntityTypeType valid_entity_types[]  = {
 
 static const FeatureTypeType use_case_scenario_support_1_features[] = {kFeatureTypeTypeLoadControl};
 static const FeatureTypeType use_case_scenario_support_2_features[] = {kFeatureTypeTypeDeviceConfiguration};
-#if 0
 static const FeatureTypeType use_case_scenario_support_3_features[] = {kFeatureTypeTypeDeviceDiagnosis};
-#endif
 static const FeatureTypeType use_case_scenario_support_4_features[] = {kFeatureTypeTypeElectricalConnection};
 
 static const UseCaseScenario use_case_scenarios[] = {
@@ -56,14 +54,12 @@ static const UseCaseScenario use_case_scenarios[] = {
      .server_features      = use_case_scenario_support_2_features,
      .server_features_size = ARRAY_SIZE(use_case_scenario_support_2_features),
      },
-#if 0
     {
      .scenario             = (UseCaseScenarioSupportType)3,
      .mandatory            = true,
      .server_features      = use_case_scenario_support_3_features,
      .server_features_size = ARRAY_SIZE(use_case_scenario_support_3_features),
      },
-#endif
     {
      .scenario             = (UseCaseScenarioSupportType)4,
      .mandatory            = false,

--- a/src/use_case/actor/eg/lpp/eg_lpp.c
+++ b/src/use_case/actor/eg/lpp/eg_lpp.c
@@ -36,9 +36,7 @@ static const EntityTypeType valid_entity_types[]  = {
 
 static const FeatureTypeType use_case_scenario_support_1_features[] = {kFeatureTypeTypeLoadControl};
 static const FeatureTypeType use_case_scenario_support_2_features[] = {kFeatureTypeTypeDeviceConfiguration};
-#if 0
 static const FeatureTypeType use_case_scenario_support_3_features[] = {kFeatureTypeTypeDeviceDiagnosis};
-#endif
 static const FeatureTypeType use_case_scenario_support_4_features[] = {kFeatureTypeTypeElectricalConnection};
 
 static const UseCaseScenario use_case_scenarios[] = {
@@ -54,14 +52,12 @@ static const UseCaseScenario use_case_scenarios[] = {
      .server_features      = use_case_scenario_support_2_features,
      .server_features_size = ARRAY_SIZE(use_case_scenario_support_2_features),
      },
-#if 0
     {
      .scenario             = (UseCaseScenarioSupportType)3,
      .mandatory            = true,
      .server_features      = use_case_scenario_support_3_features,
      .server_features_size = ARRAY_SIZE(use_case_scenario_support_3_features),
      },
-#endif
     {
      .scenario             = (UseCaseScenarioSupportType)4,
      .mandatory            = false,

--- a/tests/src/use_case/actor/eg/lpc/send/use_case_data_reply.inc
+++ b/tests/src/use_case/actor/eg/lpc/send/use_case_data_reply.inc
@@ -90,6 +90,7 @@ static constexpr char use_case_data_reply[] = R"({
                                 "scenarioSupport": [
                                   1,
                                   2,
+                                  3,
                                   4
                                 ]
                               },

--- a/tests/src/use_case/actor/eg/lpp/send/use_case_data_reply.inc
+++ b/tests/src/use_case/actor/eg/lpp/send/use_case_data_reply.inc
@@ -90,6 +90,7 @@ static constexpr char use_case_data_reply[] = R"({
                                 "scenarioSupport": [
                                   1,
                                   2,
+                                  3,
                                   4
                                 ]
                               },


### PR DESCRIPTION
Fixes #46.

Removes the `#if 0` around the scenario 3 entries in `eg_lpc.c` and `eg_lpp.c` so the energy guard announces the mandatory heartbeat scenario, and updates the two send-side golden files from `[1, 2, 4]` to `[1, 2, 3, 4]` — the receive-side fixtures already expected this from the remote peer. No functional code paths change; the heartbeat machinery itself (DeviceDiagnosis server feature, HeartbeatManager, device tick) was already in place and active.

### Verification

- **Hardware:** Elli Charger Connect 2 (Kontron GhostOne, `R04.004.045.303-elli`), EG-LPC role. Without the announcement the wallbox never subscribes to the EG's DeviceDiagnosis feature and drops the SHIP connection ~5 s after connect; with it, the wallbox subscribes, heartbeat notifies flow at the configured interval, and the connection is stable (hours). Limit writes with wallbox confirmation work end-to-end.
- **Tests:** all 672 unit tests pass (`ctest`), including the updated use-case golden files.
- **Style:** `scripts/codestyle/format_diff.sh` reports no differences.

Authored with Claude Code (Fable 5) — see commit trailer; reviewed and hardware-verified by a human.