### PR TITLE
ship_node: drop unused pthread.h and signal.h includes

### DIFF
--- a/src/ship/ship_node/ship_node.c
+++ b/src/ship/ship_node/ship_node.c
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include <pthread.h>
-#include <signal.h>
 #include <stdbool.h>
 #include <string.h>
 


### PR DESCRIPTION
Neither header is used in this file. Removing them also unblocks embedded ports that build without a POSIX compatibility layer (e.g. Zephyr), where the headers do not exist.