### PR TITLE
Defer cancelled SHIP connection teardown

### DIFF
--- a/src/ship/ship_node/ship_node.c
+++ b/src/ship/ship_node/ship_node.c
@@ -785,8 +785,6 @@ void ShipNodeCancelPairingSki(ShipNodeObject* self, const char* ski) {
     const char* const conn_ski = SHIP_CONNECTION_GET_REMOTE_SKI(sn->ship_connection);
     if (SkiMatches(ski, conn_ski)) {
       sc = sn->ship_connection;
-
-      sn->ship_connection = NULL;
     }
   }
 
@@ -794,7 +792,6 @@ void ShipNodeCancelPairingSki(ShipNodeObject* self, const char* ski) {
 
   if (sc != NULL) {
     SHIP_CONNECTION_CLOSE_CONNECTION(sc, true, 0, "pairing cancelled");
-    ShipConnectionDelete(sc);
   }
 }
 

--- a/tests/src/ship/ship_node/CMakeLists.txt
+++ b/tests/src/ship/ship_node/CMakeLists.txt
@@ -147,3 +147,8 @@ target_link_libraries(
   ${LIBWEBSOCKETS_TARGET}
   ${OPEN_SSL_LIBRARIES}
 )
+
+add_test(
+  NAME ${TEST_NAME}
+  COMMAND ${TEST_NAME}
+)

--- a/tests/src/ship/ship_node/ship_node_test.cpp
+++ b/tests/src/ship/ship_node/ship_node_test.cpp
@@ -15,16 +15,89 @@
  */
 #include "src/ship/ship_node/ship_node.h"
 
+#include <atomic>
 #include <iostream>
 #include <memory>
 
 #include "src/common/eebus_arguments.h"
 #include "src/common/eebus_device_info.h"
+#include "src/common/eebus_malloc.h"
 #include "src/common/eebus_thread/eebus_thread.h"
 #include "src/ship/ship_connection/ship_connection.h"
 #include "src/ship/ship_connection/ship_connection_internal.h"
 #include "src/ship/ship_node/ship_node_internal.h"
 #include "tests/src/memory_leak.inc"
+
+typedef struct TestShipConnection TestShipConnection;
+
+struct TestShipConnection {
+  ShipConnectionObject obj;
+  InfoProviderObject* info_provider;
+  const char* remote_ski;
+};
+
+static std::atomic<int> close_connection_count{0};
+static std::atomic<int> destruct_count{0};
+static std::atomic<int> stop_count{0};
+static std::atomic<int> disconnected_count{0};
+
+static void TestShipConnectionDestruct(DataWriterObject* self) {
+  UNUSED(self);
+  destruct_count++;
+}
+
+static void TestShipConnectionClose(ShipConnectionObject* self, bool safe, int32_t code, const char* reason) {
+  UNUSED(safe);
+  UNUSED(code);
+  UNUSED(reason);
+  close_connection_count++;
+  TestShipConnection* const connection = reinterpret_cast<TestShipConnection*>(self);
+  INFO_PROVIDER_HANDLE_CONNECTION_CLOSED(connection->info_provider, self, true);
+}
+
+static void TestShipConnectionStop(ShipConnectionObject* self) {
+  UNUSED(self);
+  stop_count++;
+}
+
+static const char* TestShipConnectionGetRemoteSki(ShipConnectionObject* self) {
+  return reinterpret_cast<TestShipConnection*>(self)->remote_ski;
+}
+
+static ShipConnectionObject* TestShipConnectionCreate(InfoProviderObject* info_provider, const char* remote_ski) {
+  static ShipConnectionInterface interface_ = {};
+  interface_.data_writer_interface.destruct = TestShipConnectionDestruct;
+  interface_.stop                           = TestShipConnectionStop;
+  interface_.close_connection               = TestShipConnectionClose;
+  interface_.get_remote_ski                 = TestShipConnectionGetRemoteSki;
+
+  TestShipConnection* const connection = static_cast<TestShipConnection*>(EEBUS_MALLOC(sizeof(TestShipConnection)));
+  connection->obj.interface_           = &interface_;
+  connection->info_provider            = info_provider;
+  connection->remote_ski               = remote_ski;
+  return SHIP_CONNECTION_OBJECT(connection);
+}
+
+static void TestShipNodeReaderOnRemoteSkiDisconnected(ShipNodeReaderObject* self, const char* ski) {
+  UNUSED(self);
+  UNUSED(ski);
+  disconnected_count++;
+}
+
+static void TestShipNodeReaderOnRemoteServicesUpdate(ShipNodeReaderObject* self, const Vector* entries) {
+  UNUSED(self);
+  UNUSED(entries);
+}
+
+static ShipNodeReaderObject* TestShipNodeReaderCreate(void) {
+  static ShipNodeReaderInterface interface_ = {};
+  interface_.on_remote_ski_disconnected     = TestShipNodeReaderOnRemoteSkiDisconnected;
+  interface_.on_remote_services_update      = TestShipNodeReaderOnRemoteServicesUpdate;
+
+  static ShipNodeReaderObject reader = {};
+  reader.interface_                  = &interface_;
+  return &reader;
+}
 
 ShipConnectionObject* ShipConnectionCreate(
     InfoProviderObject* info_provider,
@@ -56,6 +129,8 @@ int main() {
     return -1;
   }
 
+  ShipNodeReaderObject* const ship_node_reader = TestShipNodeReaderCreate();
+
   std::unique_ptr<ShipNodeObject, decltype(&ShipNodeDelete)> ship_node{
       ShipNodeCreate(
           "test_ski",
@@ -64,7 +139,7 @@ int main() {
           "ship_node_test_service",
           6677,
           nullptr,
-          nullptr,
+          ship_node_reader,
           nullptr
       ),
       &ShipNodeDelete
@@ -73,8 +148,40 @@ int main() {
   // Start the ship node
   SHIP_NODE_START(ship_node.get());
 
-  // Wait for 1 second
+  ShipNode* const internal = SHIP_NODE(ship_node.get());
+  ShipConnectionObject* const connection
+      = TestShipConnectionCreate(INFO_PROVIDER_OBJECT(ship_node.get()), "remote_ski");
+  internal->ship_connection = connection;
+
+  SHIP_NODE_CANCEL_PAIRING_WITH_SKI(ship_node.get(), "remote_ski");
+
+  // Allow the connection loop to process the cancellation message.
   EebusThreadSleep(1);
+
+  if (close_connection_count.load() != 1) {
+    std::cout << "Expected one close request, got " << close_connection_count.load() << "\n";
+    return -1;
+  }
+
+  if (stop_count.load() != 1) {
+    std::cout << "Expected one connection stop, got " << stop_count.load() << "\n";
+    return -1;
+  }
+
+  if (disconnected_count.load() != 1) {
+    std::cout << "Expected one disconnect notification, got " << disconnected_count.load() << "\n";
+    return -1;
+  }
+
+  if (destruct_count.load() != 1) {
+    std::cout << "Expected one connection destruction, got " << destruct_count.load() << "\n";
+    return -1;
+  }
+
+  if (internal->ship_connection != nullptr) {
+    std::cout << "ShipNode retained the connection after its close callback\n";
+    return -1;
+  }
 
   // Stop the ship node
   SHIP_NODE_STOP(ship_node.get());


### PR DESCRIPTION
## Problem

Follow-up to #43: `ShipNodeCancelPairingSki()` clears `ship_connection` and deletes it immediately after requesting close. `ShipConnection::CloseConnection()` reports closure synchronously, but `CloseShipConnection()` then no longer recognizes the connection as current. The regular stop and remote-SKI-disconnected notification path is skipped.

## Change

Keep the cancelled connection owned by `ShipNode` until its close callback is processed. The existing close handler then stops and deletes the connection and reports the remote SKI disconnect exactly once.

Extend the ShipNode test with a cancellation regression and register the existing executable with CTest.

## Verification

- clang-format 18: clean
- focused `ship_node_test`: passed
- GCC 14 / Debian Trixie: complete host test suite passed