### PR TITLE
Support multiple FreeRTOS mDNS instances

### DIFF
--- a/src/ship/mdns/ship_mdns_freertos.c
+++ b/src/ship/mdns/ship_mdns_freertos.c
@@ -69,14 +69,8 @@ struct Mdns {
   Vector* found_entries;
   EebusThreadObject* thread;
   SemaphoreHandle_t semaphore;
+  bool service_registered;
 };
-
-/**
- * @brief Currently only single mDNS instance is supported,
- * pointer to be used within the MdnsQueryNotifyCallback()
- * as there is no possibility to assign context to the query
- */
-static Mdns* mdns_inst = NULL;
 
 #define MDNS(obj) ((Mdns*)(obj))
 
@@ -128,9 +122,12 @@ EebusError MdnsConstruct(
   self->port                = port;
   self->autoaccept          = false;
   self->found_entries       = VectorCreateWithDeallocator(MdnsEntryDeallocator);
+  self->thread              = NULL;
   self->semaphore           = xSemaphoreCreateBinary();
-
-  mdns_inst = self;
+  self->service_registered  = false;
+  if (self->semaphore == NULL) {
+    return kEebusErrorMemoryAllocate;
+  }
 
   return kEebusErrorOk;
 }
@@ -161,8 +158,6 @@ ShipMdnsObject* ShipMdnsCreate(
 void Destruct(ShipMdnsObject* self) {
   Mdns* const mdns = MDNS(self);
 
-  mdns_inst = NULL;
-
   SHIP_MDNS_STOP(self);
 
   if (mdns->found_entries != NULL) {
@@ -170,6 +165,11 @@ void Destruct(ShipMdnsObject* self) {
     VectorDestruct(mdns->found_entries);
     EEBUS_FREE(mdns->found_entries);
     mdns->found_entries = NULL;
+  }
+
+  if (mdns->semaphore != NULL) {
+    vSemaphoreDelete(mdns->semaphore);
+    mdns->semaphore = NULL;
   }
 
   EebusDeviceInfoDelete(mdns->device_info);
@@ -211,12 +211,6 @@ MdnsEntry* MdnsEntryCreateWithMdnsResult(mdns_result_t* result) {
   return entry;
 }
 
-void MdnsQueryNotifyCallback(mdns_search_once_t* search) {
-  Mdns* mdns = mdns_inst;
-
-  xSemaphoreGive(mdns->semaphore);
-}
-
 static void MdnsNotifyFoundEntries(Mdns* mdns) {
   const size_t found_count = VectorGetSize(mdns->found_entries);
   Vector* const copy       = VectorCreateWithDeallocator(MdnsEntryDeallocator);
@@ -231,17 +225,9 @@ static void MdnsNotifyFoundEntries(Mdns* mdns) {
   mdns->on_entries_found_cb(copy, mdns->context);
 }
 
-void MdnsProcessSearchResult(Mdns* mdns, mdns_search_once_t* search) {
-  mdns_result_t* results = NULL;
-
-  bool finished = mdns_query_async_get_results(search, 0, &results, NULL);
-  if (!finished) {
-    MDNS_DEBUG_PRINTF("mdns_query_async_get_results() not finished\n");
-    return;
-  }
-
+void MdnsProcessSearchResult(Mdns* mdns, mdns_result_t* results) {
   if (results == NULL) {
-    MDNS_DEBUG_PRINTF("mdns_query_async_get_results() returned no results\n");
+    MDNS_DEBUG_PRINTF("mDNS query returned no results\n");
     return;
   }
 
@@ -278,26 +264,18 @@ uint32_t GetUpdateIntervalMs(void) {
 void* MdnsBrowserLoop(void* parameters) {
   Mdns* const mdns = (Mdns*)parameters;
 
-  mdns_search_once_t* search = NULL;
-
   while (!mdns->cancel) {
     VectorFreeElements(mdns->found_entries);
 
-    search = mdns_query_async_new(
-        NULL,
-        kShipServiceType,
-        kShipServiceProtocol,
-        MDNS_TYPE_PTR,
-        kMdnsQueryTimeoutMs,
-        kMdnsQueryMaxResults,
-        MdnsQueryNotifyCallback
-    );
+    mdns_result_t* results = NULL;
+    const esp_err_t err
+        = mdns_query_ptr(kShipServiceType, kShipServiceProtocol, kMdnsQueryTimeoutMs, kMdnsQueryMaxResults, &results);
 
-    xSemaphoreTake(mdns->semaphore, portMAX_DELAY);
-
-    MdnsProcessSearchResult(mdns, search);
-    mdns_query_async_delete(search);
-    search = NULL;
+    if (err == ESP_OK) {
+      MdnsProcessSearchResult(mdns, results);
+    } else {
+      MDNS_DEBUG_PRINTF("mdns_query_ptr() failed: %d\n", err);
+    }
 
     if (!mdns->cancel) {
       const TickType_t timeout = pdMS_TO_TICKS(GetUpdateIntervalMs());
@@ -310,12 +288,6 @@ void* MdnsBrowserLoop(void* parameters) {
 
 EebusError RegisterService(ShipMdnsObject* self) {
   Mdns* const mdns = MDNS(self);
-
-  esp_err_t err = mdns_instance_name_set(mdns->service_name);
-  if (err != ESP_OK) {
-    MDNS_DEBUG_PRINTF("mdns_instance_name_set() failed: %d\n", err);
-    return kEebusErrorInit;
-  }
 
   const char* register_str = mdns->autoaccept ? "true" : "false";
 
@@ -332,7 +304,7 @@ EebusError RegisterService(ShipMdnsObject* self) {
   };
 
   // Initialize service
-  err = mdns_service_add(
+  const esp_err_t err = mdns_service_add(
       mdns->service_name,
       kShipServiceType,
       kShipServiceProtocol,
@@ -346,6 +318,7 @@ EebusError RegisterService(ShipMdnsObject* self) {
     return kEebusErrorInit;
   }
 
+  mdns->service_registered = true;
   return kEebusErrorOk;
 }
 
@@ -383,6 +356,8 @@ static esp_netif_t* MdnsGetEspNetif(Mdns* self) {
 EebusError Start(ShipMdnsObject* self) {
   Mdns* const mdns = MDNS(self);
 
+  mdns->cancel = false;
+
   // mdns_init() may return ESP_ERR_INVALID_STATE when the host framework has
   // already initialized mDNS — that is fine, reuse it.
   esp_err_t err = mdns_init();
@@ -416,6 +391,7 @@ EebusError Start(ShipMdnsObject* self) {
   mdns->thread = EebusThreadCreate(MdnsBrowserLoop, mdns, 4096);
   if (mdns->thread == NULL) {
     MDNS_DEBUG_PRINTF("EebusThreadCreate() failed\n");
+    DeregisterService(self);
     return kEebusErrorThread;
   }
 
@@ -434,7 +410,14 @@ void DeregisterService(ShipMdnsObject* self) {
     mdns->thread = NULL;
   }
 
-  mdns_free();
+  if (mdns->service_registered) {
+    const esp_err_t err
+        = mdns_service_remove_for_host(mdns->service_name, kShipServiceType, kShipServiceProtocol, NULL);
+    if (err != ESP_OK && err != ESP_ERR_NOT_FOUND) {
+      MDNS_DEBUG_PRINTF("mdns_service_remove_for_host() failed: %d\n", err);
+    }
+    mdns->service_registered = false;
+  }
 }
 
 void Stop(ShipMdnsObject* self) {


### PR DESCRIPTION
## Problem

Follow-up to #35 and complementary to the per-`DeviceLocal` event isolation in #44: the FreeRTOS mDNS backend still routes asynchronous query completion through one process-global `mdns_inst`. With multiple OpenEEBUS services, only the last-created instance receives query completion. Stopping one instance also calls `mdns_free()`, which tears down the daemon shared by the other instances and the host application.

## Change

- use the synchronous `mdns_query_ptr()` API from each instance's existing browser thread, removing the global callback owner;
- retain browsing and the existing update interval;
- remove only the service entry registered by the stopping instance;
- keep the shared mDNS daemon running;
- initialize and release per-instance thread/semaphore resources; and
- track successful service registration so partial construction and repeated stop remain safe.

No public OpenEEBUS API changes are introduced.

## Verification

- clang-format 18: clean
- ESP32-S3 Xtensa / ESP-IDF 5.5.4 target object: compiled successfully
- GCC 14 / Debian Trixie: complete host test suite passed

The target compile used Espressif mDNS 1.11.0, where multiple service instances are enabled by default.